### PR TITLE
Add note about packer plugin order to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Plug 'folke/tokyonight.nvim'
 
 [packer](https://github.com/wbthomason/packer.nvim)
 
+**Note:** It is advised to call tokyonight last in the packer plugin order,
+doing otherwise may result in the colors being overriden by other plugins
+
 ```lua
 use 'folke/tokyonight.nvim'
 ```


### PR DESCRIPTION
If the theme is installed by packer before other plugins it causes some colors to be overriden. For example when using 
`:G diff` from [vim-fugitive] the `diffRemoved` etc colours revert to default. The only way to correct them is to call `:colorscheme tokyonight` again, once the file is open.

So it seems best to install tokyonight _last_ when using packer.

<img width="1281" alt="Screenshot 2021-04-21 at 12 25 23" src="https://user-images.githubusercontent.com/1729878/115555075-08742680-a2a7-11eb-9358-0ef4ac8254df.png">

<img width="506" alt="Screenshot 2021-04-21 at 12 27 34" src="https://user-images.githubusercontent.com/1729878/115555105-1033cb00-a2a7-11eb-9aa1-799898b5b004.png">

[vim-fugitive]: https://github.com/tpope/vim-fugitive