### PR TITLE
Add support for vim-sneak

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A dark Neovim theme written in Lua ported from the Visual Studio Code [TokyoNigh
 + [BufferLine](https://github.com/akinsho/nvim-bufferline.lua)
 + [Lualine](https://github.com/hoob3rt/lualine.nvim)
 + [Neogit](https://github.com/TimUntersberger/neogit)
++ [vim-sneak](https://github.com/justinmk/vim-sneak)
 
 ## ⚡️ Requirements
 

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -307,6 +307,9 @@ function M.setup(config)
     BufferLineIndicatorSelected = { fg = c.git.change },
     BufferLineFill = { bg = c.black },
 
+    -- Sneak
+    Sneak = { fg = c.bg_highlight, bg = c.magenta },
+    SneakScope = { bg = c.bg_visual }
   }
 
   -- LuaLine


### PR DESCRIPTION
Add highlights to support the [vim-sneak] plugin.

**Screenshots**

<details><summary>Before</summary>

<!-- Image here -->
<img width="927" alt="Screenshot 2021-04-21 at 14 00 56" src="https://user-images.githubusercontent.com/1729878/115559019-352a3d00-a2ab-11eb-826b-2a9523a5ee64.png">

</details>

<details><summary>After</summary>

<!-- Image here -->
<img width="927" alt="Screenshot 2021-04-21 at 14 00 25" src="https://user-images.githubusercontent.com/1729878/115559107-4b37fd80-a2ab-11eb-8703-0bf86ed98aee.png">

</details>

[vim-sneak]: https://github.com/justinmk/vim-sneak