### PR TITLE
Fixed transparency issue in SignColumn.

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -35,7 +35,7 @@ function M.setup(config)
     VertSplit = { fg = c.border }, -- the column separating vertically split windows
     Folded = { fg = c.blue, bg = c.fg_gutter }, -- line used for closed folds
     FoldColumn = { bg = c.bg, fg = c.comment }, -- 'foldcolumn'
-    SignColumn = { bg = c.bg, fg = c.fg_gutter }, -- column where |signs| are displayed
+    SignColumn = { bg = config.transparent and c.none or c.bg, fg = c.fg_gutter }, -- column where |signs| are displayed
     SignColumnSB = { bg = c.bg_sidebar, fg = c.fg_gutter }, -- column where |signs| are displayed
     Substitute = { bg = c.red }, -- |:substitute| replacement text highlighting
     LineNr = { fg = c.fg_gutter }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.


### PR DESCRIPTION
Changing the SignColumn to be transparent when the config has transparency turned on. Otherwise you'll get a solid block in-between git signs.