### PR TITLE
Add different highlight color for 'diff text'

### DIFF
--- a/lua/tokyonight/colors.lua
+++ b/lua/tokyonight/colors.lua
@@ -39,7 +39,7 @@ function M.setup(config)
     teal = "#1abc9c",
     red = "#f7768e",
     red1 = "#db4b4b",
-    diff = { change = "#394b70", add = "#164846", delete = "#823c41" },
+    diff = { change = "#394b70", add = "#164846", delete = "#823c41", text = '#E0AF68' },
     git = { change = "#6183bb", add = "#449dab", delete = "#f7768e" },
   }
   if config.style == "night" or vim.o.background == "light" then colors.bg = "#1a1b26" end

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -27,7 +27,7 @@ function M.setup(config)
     DiffAdd = { bg = c.diff.add }, -- diff mode: Added line |diff.txt|
     DiffChange = { bg = c.diff.change }, -- diff mode: Changed line |diff.txt|
     DiffDelete = { bg = c.diff.delete }, -- diff mode: Deleted line |diff.txt|
-    DiffText = { bg = c.diff.change }, -- diff mode: Changed text within a changed line |diff.txt|
+    DiffText = { bg = c.diff.text, fg = c.diff.change }, -- diff mode: Changed text within a changed line |diff.txt|
     EndOfBuffer = { fg = c.bg }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
     -- TermCursor  = { }, -- cursor in a focused terminal
     -- TermCursorNC= { }, -- cursor in an unfocused terminal


### PR DESCRIPTION
When looking at diffs, it is very useful to not only see if a line
changed, but also have a highlight for what exactly changed within the
line.