### PR TITLE
Add terminal-debug colors

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -138,6 +138,9 @@ function M.setup(config)
     markdownH2 = { fg = c.blue, style = "bold" },
     markdownH2Delimiter = { fg = c.blue },
 
+    debugPC = { bg = c.bg_sidebar }, -- used for highlighting the current line in terminal-debug
+    debugBreakpoint = { bg = util.darken(c.info, 0.1), fg = c.info }, -- used for breakpoint colors in terminal-debug
+
     -- These groups are for the native LSP client. Some other LSP clients may
     -- use these groups, or use their own. Consult your LSP client's
     -- documentation.


### PR DESCRIPTION
I am using the integrated [terminal-debug](https://vimhelp.org/terminal.txt.html#terminal-debug) neovim plugin and I wanted to have nicer colors than the default ones. I thought I'd add an upstream PR for this:

![image](https://user-images.githubusercontent.com/2174084/117061386-6894af00-ad22-11eb-9570-fc5b18e80e40.png)

☝️ `2` is the breakpoint number here