### PR TITLE
fix: NvimTreeSymlink and NvimTreeImageFile

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -291,6 +291,8 @@ function M.setup(config)
     LspDiagnosticsInformation = { fg = c.info },
     LspDiagnosticsHint = { fg = c.hint },
     NvimTreeIndentMarker = { fg = c.fg_gutter },
+		NvimTreeImageFile = {fg = c.fg_sidebar},
+		NvimTreeSymlink = {fg = c.blue},
     -- NvimTreeFolderName= { fg = c.fg_float },
 
     -- Dashboard


### PR DESCRIPTION
I updated NvimTreeSymlink and NvimTreeImageFile.

Tell me what your are thinking about the colors @folke 

Before
![Screenshot from 2021-05-09 00-38-09](https://user-images.githubusercontent.com/12990773/117555372-efb59000-b05e-11eb-8f3a-a9efe8e53408.png)


After
![Screenshot from 2021-05-09 00-31-40](https://user-images.githubusercontent.com/12990773/117555318-7ae25600-b05e-11eb-8f06-bb2e6991b161.png)
