### PR TITLE
Change TSTextReference from red to teal

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -240,7 +240,7 @@ function M.setup(config)
     -- TSTag               = { };    -- Tags like html tag names.
     -- TSTagDelimiter      = { };    -- Tag delimiter like `<` `>` `/`
     -- TSText              = { };    -- For strings considered text in a markup language.
-    TSTextReference = { fg = c.red }, -- FIXME
+    TSTextReference = { fg = c.teal },
     -- TSEmphasis          = { };    -- For text to be represented with emphasis.
     -- TSUnderline         = { };    -- For text to be represented with an underline.
     -- TSStrike            = { };    -- For strikethrough text.


### PR DESCRIPTION
Hi, when editing text having these highlighted with red makes them hard to distinguish from words marked from the spellchecker. I chose teal, but really any non-red color will do, or even the default (constant)