### PR TITLE
feat: add lightline tab colors

### DIFF
--- a/lua/lightline/colorscheme/tokyonight.lua
+++ b/lua/lightline/colorscheme/tokyonight.lua
@@ -30,6 +30,13 @@ tokyonight.inactive = {
   right = {{ colors.fg_gutter, colors.bg_statusline }, {colors.dark3, colors.bg }},
 }
 
+tokyonight.tabline = {
+  left = {{ colors.dark3, colors.bg_highlight }, {colors.dark3, colors.bg }},
+  middle = {{ colors.fg_gutter, colors.bg_statusline }},
+  right = {{ colors.fg_gutter, colors.bg_statusline }, {colors.dark3, colors.bg }},
+  tabsel = {{ colors.blue, colors.fg_gutter }, { colors.dark3, colors.bg }},
+}
+
 if vim.o.background == "light" then
   for _, mode in pairs(tokyonight) do
     for _, section in pairs(mode) do


### PR DESCRIPTION
I know that "buffer tabs" are all the rage but looks like the tab coloring is missing for Lightline. Feel free to change the colors or suggest different ones. For reference, Kitty tabs are the outer window.

Current lightline tab colors:
<img width="913" alt="Screen Shot 2021-06-24 at 3 53 13 PM" src="https://user-images.githubusercontent.com/100535/123343393-eac57680-d50e-11eb-9366-d5192891eaf6.png">

With this PR:
<img width="887" alt="Screen Shot 2021-06-24 at 4 49 17 PM" src="https://user-images.githubusercontent.com/100535/123343420-f4e77500-d50e-11eb-9f95-ed51d15b3f8a.png">
