### PR TITLE
feat: Add support for Barbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A dark and light Neovim theme written in Lua ported from the Visual Studio Code 
 - [Neogit](https://github.com/TimUntersberger/neogit)
 - [vim-sneak](https://github.com/justinmk/vim-sneak)
 - [Fern](https://github.com/lambdalisue/fern.vim)
+- [Barbar](https://github.com/romgrk/barbar.nvim)
 
 ## ⚡️ Requirements
 

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -367,6 +367,25 @@ function M.setup(config)
     BufferLineIndicatorSelected = { fg = c.git.change },
     BufferLineFill = { bg = c.black },
 
+    -- Barbar
+    BufferCurrent = { bg = c.fg_gutter, fg = c.fg },
+    BufferCurrentIndex = { bg = c.fg_gutter, fg = c.info },
+    BufferCurrentMod = { bg = c.fg_gutter, fg = c.warning },
+    BufferCurrentSign = { bg = c.fg_gutter, fg = c.info },
+    BufferCurrentTarget = { bg = c.fg_gutter, fg = c.red },
+    BufferVisible = { bg = c.bg_statusline, fg = c.fg },
+    BufferVisibleIndex = { bg = c.bg_statusline, fg = c.info },
+    BufferVisibleMod = { bg = c.bg_statusline, fg = c.warning },
+    BufferVisibleSign = { bg = c.bg_statusline, fg = c.info },
+    BufferVisibleTarget = { bg = c.bg_statusline, fg = c.red },
+    BufferInactive = { bg = c.bg_statusline, fg = c.dark5 },
+    BufferInactiveIndex = { bg = c.bg_statusline, fg = c.dark5 },
+    BufferInactiveMod = { bg = c.bg_statusline, fg = util.darken(c.warning, 0.7) },
+    BufferInactiveSign = { bg = c.bg_statusline, fg = c.border_highlight },
+    BufferInactiveTarget = { bg = c.bg_statusline, fg = c.red },
+    BufferTabpages = { bg = c.bg_statusline, fg = c.none },
+    BufferTabpage = { bg = c.bg_statusline, fg = c.border_highlight },
+
     -- Sneak
     Sneak = { fg = c.bg_highlight, bg = c.magenta },
     SneakScope = { bg = c.bg_visual },


### PR DESCRIPTION
The default colors were okay, but what was driving me crazy was the "visible but not active" style was way more visible than the "visible and active". Example below: `colorscheme/tokyonight.lua` is the buffer that my cursor is currently in, and `themes/tokyonight.lua` is also visible in the tabpage.
![Screenshot from 2021-06-28 15-44-51](https://user-images.githubusercontent.com/506791/123712927-2bcbcc80-d828-11eb-9d3c-51b183f7a107.png)

With this PR (`style='storm'`):
![Screenshot from 2021-06-28 16-02-28](https://user-images.githubusercontent.com/506791/123714095-8b2adc00-d82a-11eb-8f49-b921430ea56d.png)


`style = 'night'`
![Screenshot from 2021-06-28 16-03-15](https://user-images.githubusercontent.com/506791/123713975-60408800-d82a-11eb-9bd6-805bf94b5201.png)

`style = 'day'`
![Screenshot from 2021-06-28 16-03-48](https://user-images.githubusercontent.com/506791/123714041-764e4880-d82a-11eb-98ed-fc06d9db9bfd.png)

I don't think I have a particularly keen eye for colors, so I'm open to any feedback about tweaking the palette