### PR TITLE
fix: vim-plug needs info for non-master defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Install the theme with your preferred package manager:
 [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'folke/tokyonight.nvim'
+Plug 'folke/tokyonight.nvim', { 'branch': 'main' }
 ```
 
 [packer](https://github.com/wbthomason/packer.nvim)


### PR DESCRIPTION
# Info
Otherwise on `:PlugInstall` it complains there's no reference for `master`