### PR TITLE
feat: Add support for configuring transparent sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The **day** style will be used if:
 | tokyonight_transparent              | `false`   | Enable this to disable setting the background color                                                                                                             |
 | tokyonight_hide_inactive_statusline | `false`   | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |
 | tokyonight_sidebars                 | `{}`      | Set a darker background on sidebar-like windows. For example: `["qf", "vista_kind", "terminal", "packer"]`                                                      |
+| tokyonight_transparent_sidebar      | `false`   | Sidebar like windows like `NvimTree` get a transparent background
 | tokyonight_dark_sidebar             | `true`    | Sidebar like windows like `NvimTree` get a darker background                                                                                                    |
 | tokyonight_dark_float               | `true`    | Float windows like the lsp diagnostics windows get a darker background.                                                                                         |
 | tokyonight_colors                   | `{}`      | You can override specific color groups to use other groups or a hex color                                                                                       |

--- a/lua/tokyonight/colors.lua
+++ b/lua/tokyonight/colors.lua
@@ -74,7 +74,7 @@ function M.setup(config)
   colors.bg_statusline = colors.bg_dark
 
   -- Sidebar and Floats are configurable
-  colors.bg_sidebar = config.darkSidebar and colors.bg_dark or colors.bg
+  colors.bg_sidebar = (config.transparentSidebar and colors.none) or config.darkSidebar and colors.bg_dark or colors.bg
   colors.bg_float = config.darkFloat and colors.bg_dark or colors.bg
 
   colors.bg_visual = util.darken(colors.blue0, 0.7)

--- a/lua/tokyonight/config.lua
+++ b/lua/tokyonight/config.lua
@@ -30,6 +30,7 @@ config = {
   dev = opt("dev", false),
   darkFloat = opt("dark_float", true),
   darkSidebar = opt("dark_sidebar", true),
+  transparentSidebar = opt("transparent_sidebar", false),
   transform_colors = false,
   lualineBold = opt("lualine_bold", false),
 }


### PR DESCRIPTION
Adds support to configuring if you want the background of the sidebar to be transparent or not.

The `default` is that the sidebar gets a background color, like the current behavior 

`vim.g.tokyonight_transparent_sidebar=false`

![Screen Shot 2021-07-14 at 00 28 00](https://user-images.githubusercontent.com/76068197/125533356-e34f3186-8c25-41e9-8379-bbdfe1d1e7c2.png)

You can also configure the bg color to be transparent

`vim.g.tokyonight_transparent_sidebar=true`

![Screen Shot 2021-07-14 at 00 27 30](https://user-images.githubusercontent.com/76068197/125533451-c09dafe9-619b-4609-84c8-b7f8ba865ec8.png)
