### PR TITLE
feat/extra: add colorscheme generator and themes for xfce4 terminal

### DIFF
--- a/extras/xfceterm_tokyonight_day.theme
+++ b/extras/xfceterm_tokyonight_day.theme
@@ -1,0 +1,9 @@
+[Scheme]
+Name=TokyoNight Colors
+ColorBackground=#1a1b26
+ColorForeground=#c0caf5
+
+ColorSelectionBackground=#33467C
+ColorSelection=#c0caf5
+
+ColorPalette=#15161E;#f7768e;#9ece6a;#e0af68;#7aa2f7;#bb9af7;#7dcfff;#a9b1d6;#414868;#f7768e;#9ece6a;#e0af68;#7aa2f7;#bb9af7;#7dcfff;#c0caf5

--- a/extras/xfceterm_tokyonight_night.theme
+++ b/extras/xfceterm_tokyonight_night.theme
@@ -1,0 +1,9 @@
+[Scheme]
+Name=TokyoNight Colors
+ColorBackground=#1a1b26
+ColorForeground=#c0caf5
+
+ColorSelectionBackground=#33467C
+ColorSelection=#c0caf5
+
+ColorPalette=#15161E;#f7768e;#9ece6a;#e0af68;#7aa2f7;#bb9af7;#7dcfff;#a9b1d6;#414868;#f7768e;#9ece6a;#e0af68;#7aa2f7;#bb9af7;#7dcfff;#c0caf5

--- a/extras/xfceterm_tokyonight_storm.theme
+++ b/extras/xfceterm_tokyonight_storm.theme
@@ -1,0 +1,9 @@
+[Scheme]
+Name=TokyoNight Colors
+ColorBackground=#24283b
+ColorForeground=#c0caf5
+
+ColorSelectionBackground=#364A82
+ColorSelection=#c0caf5
+
+ColorPalette=#1D202F;#f7768e;#9ece6a;#e0af68;#7aa2f7;#bb9af7;#7dcfff;#a9b1d6;#414868;#f7768e;#9ece6a;#e0af68;#7aa2f7;#bb9af7;#7dcfff;#c0caf5

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -17,6 +17,7 @@ local extras = {
 	wezterm = "toml",
 	tmux = "tmux",
 	xresources = "Xresources",
+	xfceterm = "theme",
 }
 local styles = { "storm", "night", "day" }
 

--- a/lua/tokyonight/extra/xfceterm.lua
+++ b/lua/tokyonight/extra/xfceterm.lua
@@ -1,0 +1,24 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+-- @param colors ColorScheme
+function M.generate(colors)
+	local xfceterm = util.template(
+		[[
+[Scheme]
+Name=TokyoNight Colors
+ColorBackground=${bg}
+ColorForeground=${fg}
+
+ColorSelectionBackground=${bg_visual}
+ColorSelection=${fg}
+
+ColorPalette=${black};${red};${green};${yellow};${blue};${magenta};${cyan};${fg_dark};${terminal_black};${red};${green};${yellow};${blue};${magenta};${cyan};${fg}
+]],
+		colors
+	)
+	return xfceterm
+end
+
+return M


### PR DESCRIPTION
I like to use xfce and the default terminal works fine for me, but I wanted to use my favorite theme with it.

For some reason when I run the colorscheme generator it is producing some pretty significant changes for the `day` variants of the existing themes, but not the night or storm ones. I found that strange, so if you notice something wrong with my changes here please let me know and I can fix. 

Thanks for your work on this theme!

![tokyonight_xfceterm](https://user-images.githubusercontent.com/8900989/126558262-24a7b92c-f74d-415f-a5e0-7b7069b6ea7f.png)
