### PR TITLE
highlight LspCodeLens with comment color

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -174,6 +174,7 @@ function M.setup(config)
     LspDiagnosticsUnderlineHint = { style = "undercurl", sp = c.hint }, -- Used to underline "Hint" diagnostics
 
     LspSignatureActiveParameter = { fg = c.orange },
+    LspCodeLens = { fg = c.comment },
 
     -- LspDiagnosticsFloatingError         = { }, -- Used to color "Error" diagnostic messages in diagnostics float
     -- LspDiagnosticsFloatingWarning       = { }, -- Used to color "Warning" diagnostic messages in diagnostics float


### PR DESCRIPTION
Currently, code lenses look like regular text when using built in LSP. This highlights them like comments so they stand out visually.

Before:
![codelens_plain_text](https://user-images.githubusercontent.com/9307830/127309061-366811df-4386-4f03-bd7f-8fd5eedacbe6.png)
After:
![codelens_comment](https://user-images.githubusercontent.com/9307830/127309077-f69b00e7-775b-4f37-9549-0ac229541a7a.png)
