### PR TITLE
Feat: Add support for configuring transparent float

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The **day** style will be used if:
 | tokyonight_sidebars                 | `{}`      | Set a darker background on sidebar-like windows. For example: `["qf", "vista_kind", "terminal", "packer"]`                                                      |
 | tokyonight_transparent_sidebar      | `false`   | Sidebar like windows like `NvimTree` get a transparent background                                                                                               |
 | tokyonight_dark_sidebar             | `true`    | Sidebar like windows like `NvimTree` get a darker background                                                                                                    |
+| tokyonight_transparent_float        | `false`   | Float windows like the lsp diagnostics windows get a transparent background.                                                                                    |
 | tokyonight_dark_float               | `true`    | Float windows like the lsp diagnostics windows get a darker background.                                                                                         |
 | tokyonight_colors                   | `{}`      | You can override specific color groups to use other groups or a hex color                                                                                       |
 | tokyonight_day_brightness           | `0.3`     | Adjusts the brightness of the colors of the **Day** style. Number between 0 and 1, from dull to vibrant colors                                                  |

--- a/lua/tokyonight/colors.lua
+++ b/lua/tokyonight/colors.lua
@@ -75,7 +75,7 @@ function M.setup(config)
 
   -- Sidebar and Floats are configurable
   colors.bg_sidebar = (config.transparentSidebar and colors.none) or config.darkSidebar and colors.bg_dark or colors.bg
-  colors.bg_float = config.darkFloat and colors.bg_dark or colors.bg
+  colors.bg_float = (config.transparentFloat and colors.none) or config.darkFloat and colors.bg_dark or colors.bg
 
   colors.bg_visual = util.darken(colors.blue0, 0.7)
   colors.bg_search = colors.blue0

--- a/lua/tokyonight/config.lua
+++ b/lua/tokyonight/config.lua
@@ -31,6 +31,7 @@ config = {
   darkFloat = opt("dark_float", true),
   darkSidebar = opt("dark_sidebar", true),
   transparentSidebar = opt("transparent_sidebar", false),
+  transparentFloat = opt("transparent_float", false),
   transform_colors = false,
   lualineBold = opt("lualine_bold", false),
 }

--- a/lua/tokyonight/config.lua
+++ b/lua/tokyonight/config.lua
@@ -15,10 +15,12 @@ local function opt(key, default)
   return vim.g[key]
 end
 
+local transparent = opt("transparent", false)
+
 config = {
   style = opt("style", "storm"),
   dayBrightness = opt("day_brightness", 0.3),
-  transparent = opt("transparent", false),
+  transparent = transparent,
   commentStyle = opt("italic_comments", true) and "italic" or "NONE",
   keywordStyle = opt("italic_keywords", true) and "italic" or "NONE",
   functionStyle = opt("italic_functions", false) and "italic" or "NONE",
@@ -28,10 +30,10 @@ config = {
   sidebars = opt("sidebars", {}),
   colors = opt("colors", {}),
   dev = opt("dev", false),
-  darkFloat = opt("dark_float", true),
-  darkSidebar = opt("dark_sidebar", true),
-  transparentSidebar = opt("transparent_sidebar", false),
-  transparentFloat = opt("transparent_float", false),
+  darkFloat = opt("dark_float", not transparent),
+  darkSidebar = opt("dark_sidebar", not transparent),
+  transparentSidebar = opt("transparent_sidebar", transparent),
+  transparentFloat = opt("transparent_float", transparent),
   transform_colors = false,
   lualineBold = opt("lualine_bold", false),
 }


### PR DESCRIPTION
This PR adds support for configuring transparent float to be consistent with transparent bgs and sidebars using the configuration `vim.g.tokyonight_transparent_float=true`

Before:
![Screenshot 2021-09-12 at 12 33 34](https://user-images.githubusercontent.com/76068197/132984363-acb913e7-c6a5-49fb-852e-dfc709d6821b.png)

After:
![Screenshot 2021-09-12 at 12 34 20](https://user-images.githubusercontent.com/76068197/132984375-3041cc79-709c-491d-a3de-bbdb55bb97b4.png)

