### PR TITLE
fix: change VertSplit bg

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -32,7 +32,7 @@ function M.setup(config)
     -- TermCursor  = { }, -- cursor in a focused terminal
     -- TermCursorNC= { }, -- cursor in an unfocused terminal
     ErrorMsg = { fg = c.error }, -- error messages on the command line
-    VertSplit = { fg = c.border }, -- the column separating vertically split windows
+    VertSplit = { fg = c.border, bg = c.bg_sidebar }, -- the column separating vertically split windows
     Folded = { fg = c.blue, bg = c.fg_gutter }, -- line used for closed folds
     FoldColumn = { bg = c.bg, fg = c.comment }, -- 'foldcolumn'
     SignColumn = { bg = config.transparent and c.none or c.bg, fg = c.fg_gutter }, -- column where |signs| are displayed


### PR DESCRIPTION
Changing VertSplit to have the same background as sidebar fixes 2 things: 

(1) Makes vertical splits more distinguishable, which is an issue that's been brought up a few times (#34 , #93). With this, splits are more obvious but still blend in with theme well (IMO)

![](https://user-images.githubusercontent.com/79729735/135168653-484afd78-7f23-4550-be14-ec27627aa78a.png)

(2) Makes sidebars more uniform with the statusline. See the gap in the statusline when a sidebar is opened (left) versus change (right)

![](https://user-images.githubusercontent.com/79729735/135167152-d3c037c8-3029-4e39-8104-fdc153e32e04.png) ![](https://user-images.githubusercontent.com/79729735/135167248-8ea66c74-a7b7-4eaa-86a2-4a8f2809a831.png)


