### PR TITLE
improved telescope background when transparency enabled

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -303,7 +303,8 @@ function M.setup(config)
     GitSignsDelete = { fg = c.gitSigns.delete }, -- diff mode: Deleted line |diff.txt|
 
     -- Telescope
-    TelescopeBorder = { fg = c.border_highlight },
+    TelescopeBorder = { fg = c.border_highlight, bg = c.bg_float },
+    TelescopeNormal = { fg = c.fg, bg = c.bg_float },
 
     -- NvimTree
     NvimTreeNormal = { fg = c.fg_sidebar, bg = c.bg_sidebar },


### PR DESCRIPTION
When transparency is enabled the background for Telescope seems to be just black. This doesn't blend well with the rest of the theme in transparency mode.

![Screen Shot 2021-12-31 at 08 36 51](https://user-images.githubusercontent.com/9951907/147812748-fe5063d3-e9ef-4bcf-b043-7e279705a5ff.png)

While the default fg and bg are not transparent, they do provide a better contrast and seems easier on the eye. Also using `pumblend` provide some transparency/opacity in Telescope, which again looks nicer I think. 

![Screen Shot 2021-12-31 at 08 35 37](https://user-images.githubusercontent.com/9951907/147812774-fe5446d0-85e5-460c-ada0-09613bbaea62.png)
