### PR TITLE
improved lualine theme for inactive status line

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -461,7 +461,7 @@ function M.setup(config)
   theme.defer = {}
 
   if config.hideInactiveStatusline then
-    local inactive = { style = "underline", bg = c.bg, fg = c.bg, sp = c.border }
+    local inactive = { style = "underline", bg = c.none, fg = c.bg, sp = c.border }
 
     -- StatusLineNC
     theme.base.StatusLineNC = inactive


### PR DESCRIPTION
When the `vim.g.tokyonight_hide_inactive_statusline` is set to, the background for lualine inactive status line should be set to none, so it is truly hidden. Also checked in `day` and `night` variants

**not really hidden**
<img width="1695" alt="Screen Shot 2021-12-31 at 09 15 02" src="https://user-images.githubusercontent.com/9951907/147814640-f4a9f6e9-7445-41ea-8e50-395bc55fb1ba.png">

**truly hidden**
<img width="1695" alt="Screen Shot 2021-12-31 at 09 15 22" src="https://user-images.githubusercontent.com/9951907/147814644-36e288a3-9564-439e-83e6-635f92ef140d.png">