### PR TITLE
Improve the cursor color of day Kitty theme

### DIFF
--- a/extras/kitty_tokyonight_day.conf
+++ b/extras/kitty_tokyonight_day.conf
@@ -12,6 +12,7 @@ selection_background #99a7df
 selection_foreground #3760bf
 url_color #387068
 cursor #3760bf
+cursor_text_color #e1e2e7
 
 # Tabs
 active_tab_background #2e7de9

--- a/extras/kitty_tokyonight_night.conf
+++ b/extras/kitty_tokyonight_night.conf
@@ -12,6 +12,7 @@ selection_background #33467C
 selection_foreground #c0caf5
 url_color #73daca
 cursor #c0caf5
+cursor_text_color #1a1b26
 
 # Tabs
 active_tab_background #7aa2f7

--- a/extras/kitty_tokyonight_storm.conf
+++ b/extras/kitty_tokyonight_storm.conf
@@ -12,6 +12,7 @@ selection_background #364A82
 selection_foreground #c0caf5
 url_color #73daca
 cursor #c0caf5
+cursor_text_color #24283b
 
 # Tabs
 active_tab_background #7aa2f7

--- a/lua/tokyonight/extra/kitty.lua
+++ b/lua/tokyonight/extra/kitty.lua
@@ -20,6 +20,7 @@ selection_background ${bg_visual}
 selection_foreground ${fg}
 url_color ${green1}
 cursor ${fg}
+cursor_text_color ${bg}
 
 # Tabs
 active_tab_background ${blue}


### PR DESCRIPTION
Previously the cursor colour would have the default foreground color which is a a bit too dark when you have a block cursor and use autocomplete features. Using the background color as the cursor text ensures that text in a block cursor is always visible.