### PR TITLE
add windows terminal to extras

### DIFF
--- a/extras/kitty_tokyonight_day.conf
+++ b/extras/kitty_tokyonight_day.conf
@@ -15,7 +15,7 @@ cursor #3760bf
 
 # Tabs
 active_tab_background #2e7de9
-active_tab_foreground #d4d6e4
+active_tab_foreground #e9e9ec
 inactive_tab_background #c4c8da
 inactive_tab_foreground #8990b3
 #tab_bar_background #e9e9ed

--- a/extras/kitty_tokyonight_night.conf
+++ b/extras/kitty_tokyonight_night.conf
@@ -15,7 +15,7 @@ cursor #c0caf5
 
 # Tabs
 active_tab_background #7aa2f7
-active_tab_foreground #1f2335
+active_tab_foreground #16161e
 inactive_tab_background #292e42
 inactive_tab_foreground #545c7e
 #tab_bar_background #15161E

--- a/extras/tmux_tokyonight_day.tmux
+++ b/extras/tmux_tokyonight_day.tmux
@@ -13,7 +13,7 @@ set -g pane-active-border-style "fg=#2e7de9"
 set -g status "on"
 set -g status-justify "left"
 
-set -g status-style "fg=#2e7de9,bg=#d4d6e4"
+set -g status-style "fg=#2e7de9,bg=#e9e9ec"
 
 set -g status-left-length "100"
 set -g status-right-length "100"
@@ -21,12 +21,12 @@ set -g status-right-length "100"
 set -g status-left-style NONE
 set -g status-right-style NONE
 
-set -g status-left "#[fg=#e9e9ed,bg=#2e7de9,bold] #S #[fg=#2e7de9,bg=#d4d6e4,nobold,nounderscore,noitalics]"
-set -g status-right "#[fg=#d4d6e4,bg=#d4d6e4,nobold,nounderscore,noitalics]#[fg=#2e7de9,bg=#d4d6e4] #{prefix_highlight} #[fg=#a8aecb,bg=#d4d6e4,nobold,nounderscore,noitalics]#[fg=#2e7de9,bg=#a8aecb] %Y-%m-%d  %I:%M %p #[fg=#2e7de9,bg=#a8aecb,nobold,nounderscore,noitalics]#[fg=#e9e9ed,bg=#2e7de9,bold] #h "
+set -g status-left "#[fg=#e9e9ed,bg=#2e7de9,bold] #S #[fg=#2e7de9,bg=#e9e9ec,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=#e9e9ec,bg=#e9e9ec,nobold,nounderscore,noitalics]#[fg=#2e7de9,bg=#e9e9ec] #{prefix_highlight} #[fg=#a8aecb,bg=#e9e9ec,nobold,nounderscore,noitalics]#[fg=#2e7de9,bg=#a8aecb] %Y-%m-%d  %I:%M %p #[fg=#2e7de9,bg=#a8aecb,nobold,nounderscore,noitalics]#[fg=#e9e9ed,bg=#2e7de9,bold] #h "
 
-setw -g window-status-activity-style "underscore,fg=#6172b0,bg=#d4d6e4"
+setw -g window-status-activity-style "underscore,fg=#6172b0,bg=#e9e9ec"
 setw -g window-status-separator ""
-setw -g window-status-style "NONE,fg=#6172b0,bg=#d4d6e4"
-setw -g window-status-format "#[fg=#d4d6e4,bg=#d4d6e4,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#d4d6e4,bg=#d4d6e4,nobold,nounderscore,noitalics]"
-setw -g window-status-current-format "#[fg=#d4d6e4,bg=#a8aecb,nobold,nounderscore,noitalics]#[fg=#2e7de9,bg=#a8aecb,bold] #I  #W #F #[fg=#a8aecb,bg=#d4d6e4,nobold,nounderscore,noitalics]"
+setw -g window-status-style "NONE,fg=#6172b0,bg=#e9e9ec"
+setw -g window-status-format "#[fg=#e9e9ec,bg=#e9e9ec,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#e9e9ec,bg=#e9e9ec,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=#e9e9ec,bg=#a8aecb,nobold,nounderscore,noitalics]#[fg=#2e7de9,bg=#a8aecb,bold] #I  #W #F #[fg=#a8aecb,bg=#e9e9ec,nobold,nounderscore,noitalics]"
   

--- a/extras/tmux_tokyonight_night.tmux
+++ b/extras/tmux_tokyonight_night.tmux
@@ -13,7 +13,7 @@ set -g pane-active-border-style "fg=#7aa2f7"
 set -g status "on"
 set -g status-justify "left"
 
-set -g status-style "fg=#7aa2f7,bg=#1f2335"
+set -g status-style "fg=#7aa2f7,bg=#16161e"
 
 set -g status-left-length "100"
 set -g status-right-length "100"
@@ -21,12 +21,12 @@ set -g status-right-length "100"
 set -g status-left-style NONE
 set -g status-right-style NONE
 
-set -g status-left "#[fg=#15161E,bg=#7aa2f7,bold] #S #[fg=#7aa2f7,bg=#1f2335,nobold,nounderscore,noitalics]"
-set -g status-right "#[fg=#1f2335,bg=#1f2335,nobold,nounderscore,noitalics]#[fg=#7aa2f7,bg=#1f2335] #{prefix_highlight} #[fg=#3b4261,bg=#1f2335,nobold,nounderscore,noitalics]#[fg=#7aa2f7,bg=#3b4261] %Y-%m-%d  %I:%M %p #[fg=#7aa2f7,bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#15161E,bg=#7aa2f7,bold] #h "
+set -g status-left "#[fg=#15161E,bg=#7aa2f7,bold] #S #[fg=#7aa2f7,bg=#16161e,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=#16161e,bg=#16161e,nobold,nounderscore,noitalics]#[fg=#7aa2f7,bg=#16161e] #{prefix_highlight} #[fg=#3b4261,bg=#16161e,nobold,nounderscore,noitalics]#[fg=#7aa2f7,bg=#3b4261] %Y-%m-%d  %I:%M %p #[fg=#7aa2f7,bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#15161E,bg=#7aa2f7,bold] #h "
 
-setw -g window-status-activity-style "underscore,fg=#a9b1d6,bg=#1f2335"
+setw -g window-status-activity-style "underscore,fg=#a9b1d6,bg=#16161e"
 setw -g window-status-separator ""
-setw -g window-status-style "NONE,fg=#a9b1d6,bg=#1f2335"
-setw -g window-status-format "#[fg=#1f2335,bg=#1f2335,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#1f2335,bg=#1f2335,nobold,nounderscore,noitalics]"
-setw -g window-status-current-format "#[fg=#1f2335,bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#7aa2f7,bg=#3b4261,bold] #I  #W #F #[fg=#3b4261,bg=#1f2335,nobold,nounderscore,noitalics]"
+setw -g window-status-style "NONE,fg=#a9b1d6,bg=#16161e"
+setw -g window-status-format "#[fg=#16161e,bg=#16161e,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#16161e,bg=#16161e,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=#16161e,bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#7aa2f7,bg=#3b4261,bold] #I  #W #F #[fg=#3b4261,bg=#16161e,nobold,nounderscore,noitalics]"
   

--- a/extras/windowsterminal_tokyonight_day..json
+++ b/extras/windowsterminal_tokyonight_day..json
@@ -1,6 +1,4 @@
 {
-    // upstream: ${_upstrean_url}
-
     "name" : "Tokyo Night Day",
 
     "cursorColor": "#3760bf",

--- a/extras/windowsterminal_tokyonight_day..json
+++ b/extras/windowsterminal_tokyonight_day..json
@@ -1,0 +1,28 @@
+{
+    // upstream: ${_upstrean_url}
+
+    "name" : "Tokyo Night Day",
+
+    "cursorColor": "#3760bf",
+    "selectionBackground": "#99a7df",
+
+    "background" : "#e1e2e7",
+    "foreground" : "#3760bf",
+
+    "black" : "#e9e9ed",
+    "blue" : "#2e7de9",
+    "cyan" : "#007197",
+    "green" : "#587539",
+    "purple" : "#9854f1",
+    "red" : "#f52a65",
+    "white" : "#3760bf",
+    "yellow" : "#8c6c3e",
+    "brightBlack" : "#a1a6c5",
+    "brightBlue" : "#2e7de9",
+    "brightCyan" : "#007197",
+    "brightGreen" : "#587539",
+    "brightPurple" : "#9854f1",
+    "brightRed" : "#f52a65",
+    "brightWhite" : "#3760bf",
+    "brightYellow" : "#8c6c3e"
+}

--- a/extras/windowsterminal_tokyonight_night..json
+++ b/extras/windowsterminal_tokyonight_night..json
@@ -1,6 +1,4 @@
 {
-    // upstream: ${_upstrean_url}
-
     "name" : "Tokyo Night",
 
     "cursorColor": "#c0caf5",

--- a/extras/windowsterminal_tokyonight_night..json
+++ b/extras/windowsterminal_tokyonight_night..json
@@ -1,0 +1,28 @@
+{
+    // upstream: ${_upstrean_url}
+
+    "name" : "Tokyo Night",
+
+    "cursorColor": "#c0caf5",
+    "selectionBackground": "#33467C",
+
+    "background" : "#1a1b26",
+    "foreground" : "#c0caf5",
+
+    "black" : "#15161E",
+    "blue" : "#7aa2f7",
+    "cyan" : "#7dcfff",
+    "green" : "#9ece6a",
+    "purple" : "#bb9af7",
+    "red" : "#f7768e",
+    "white" : "#c0caf5",
+    "yellow" : "#e0af68",
+    "brightBlack" : "#414868",
+    "brightBlue" : "#7aa2f7",
+    "brightCyan" : "#7dcfff",
+    "brightGreen" : "#9ece6a",
+    "brightPurple" : "#bb9af7",
+    "brightRed" : "#f7768e",
+    "brightWhite" : "#c0caf5",
+    "brightYellow" : "#e0af68"
+}

--- a/extras/windowsterminal_tokyonight_storm..json
+++ b/extras/windowsterminal_tokyonight_storm..json
@@ -1,0 +1,28 @@
+{
+    // upstream: ${_upstrean_url}
+
+    "name" : "Tokyo Night Storm",
+
+    "cursorColor": "#c0caf5",
+    "selectionBackground": "#364A82",
+
+    "background" : "#24283b",
+    "foreground" : "#c0caf5",
+
+    "black" : "#1D202F",
+    "blue" : "#7aa2f7",
+    "cyan" : "#7dcfff",
+    "green" : "#9ece6a",
+    "purple" : "#bb9af7",
+    "red" : "#f7768e",
+    "white" : "#c0caf5",
+    "yellow" : "#e0af68",
+    "brightBlack" : "#414868",
+    "brightBlue" : "#7aa2f7",
+    "brightCyan" : "#7dcfff",
+    "brightGreen" : "#9ece6a",
+    "brightPurple" : "#bb9af7",
+    "brightRed" : "#f7768e",
+    "brightWhite" : "#c0caf5",
+    "brightYellow" : "#e0af68"
+}

--- a/extras/windowsterminal_tokyonight_storm..json
+++ b/extras/windowsterminal_tokyonight_storm..json
@@ -1,6 +1,4 @@
 {
-    // upstream: ${_upstrean_url}
-
     "name" : "Tokyo Night Storm",
 
     "cursorColor": "#c0caf5",

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -18,6 +18,7 @@ local extras = {
 	tmux = "tmux",
 	xresources = "Xresources",
 	xfceterm = "theme",
+  windowsterminal = ".json",
 }
 -- map of style to style name
 local styles = { 

--- a/lua/tokyonight/extra/windowsterminal.lua
+++ b/lua/tokyonight/extra/windowsterminal.lua
@@ -7,8 +7,6 @@ function M.generate(colors)
   local winterm = util.template(
 [[
 {
-    // upstream: ${_upstrean_url}
-
     "name" : "${_style_name}",
 
     "cursorColor": "${fg}",

--- a/lua/tokyonight/extra/windowsterminal.lua
+++ b/lua/tokyonight/extra/windowsterminal.lua
@@ -1,0 +1,41 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @param colors ColorScheme
+function M.generate(colors)
+  local winterm = util.template(
+[[
+{
+    // upstream: ${_upstrean_url}
+
+    "name" : "${_style_name}",
+
+    "cursorColor": "${fg}",
+    "selectionBackground": "${bg_visual}",
+
+    "background" : "${bg}",
+    "foreground" : "${fg}",
+
+    "black" : "${black}",
+    "blue" : "${blue}",
+    "cyan" : "${cyan}",
+    "green" : "${green}",
+    "purple" : "${magenta}",
+    "red" : "${red}",
+    "white" : "${fg}",
+    "yellow" : "${yellow}",
+    "brightBlack" : "${terminal_black}",
+    "brightBlue" : "${blue}",
+    "brightCyan" : "${cyan}",
+    "brightGreen" : "${green}",
+    "brightPurple" : "${magenta}",
+    "brightRed" : "${red}",
+    "brightWhite" : "${fg}",
+    "brightYellow" : "${yellow}"
+}
+]], colors)
+  return winterm
+end
+
+return M


### PR DESCRIPTION
### Commits
- Added a template file for Windows Terminal Color Scheme
- Commited rest of the files in extras that changed upon regeneration with the command in the readme
- Removed the comment string to avoid GitHub errors (Windows Terminal supports it)

### Sample Image -- Tokyo Night Storm
![image](https://user-images.githubusercontent.com/50461557/155969266-a81dac60-3538-43b5-a4d9-361dd88fab09.png)