### PR TITLE
fix: terminal_colors was declared but not used

### DIFF
--- a/lua/tokyonight/util.lua
+++ b/lua/tokyonight/util.lua
@@ -236,7 +236,10 @@ function util.load(theme)
   -- load base theme
   util.syntax(theme.base)
   util.syntax(theme.plugins)
-  util.terminal(theme.colors)
+  if theme.config.terminalColors then
+    util.terminal(theme.colors)
+  end
+
   util.autocmds(theme.config)
 
   vim.defer_fn(function()


### PR DESCRIPTION
It seems that terminal_colors configuration was not used.