### PR TITLE
feat: add bg hightlight on NvimTreeOpenedFile

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -313,6 +313,7 @@ function M.setup(config)
     NvimTreeGitDirty = { fg = c.git.change },
     NvimTreeGitNew = { fg = c.git.add },
     NvimTreeGitDeleted = { fg = c.git.delete },
+    NvimTreeOpenedFile  = { bg = c.bg_highlight },
     NvimTreeSpecialFile = { fg = c.purple, style = "underline" },
     NvimTreeIndentMarker = { fg = c.fg_gutter },
     NvimTreeImageFile = { fg = c.fg_sidebar },


### PR DESCRIPTION

With:
```lua
vim.g.nvim_tree_highlight_opened_files = 2

require'nvim-tree'.setup {
    update_focused_file = {
        enable = true,
    },
}
```

and `theme.lua`open ->

<img width="263" alt="image" src="https://user-images.githubusercontent.com/11062985/161342029-15b5941f-a419-455e-9c92-ae68a195b6e7.png">
