### PR TITLE
feat: allow bg_dark on inactive buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The **day** style will be used if:
 | tokyonight_sidebars                 | `{}`      | Set a darker background on sidebar-like windows. For example: `["qf", "vista_kind", "terminal", "packer"]`                                                      |
 | tokyonight_transparent_sidebar      | `false`   | Sidebar like windows like `NvimTree` get a transparent background                                                                                               |
 | tokyonight_dark_sidebar             | `true`    | Sidebar like windows like `NvimTree` get a darker background                                                                                                    |
+| tokyonight_dark_inactive            | `false`   | Inactive/Unfocused buffers get a darker background                                                                                                              |
 | tokyonight_dark_float               | `true`    | Float windows like the lsp diagnostics windows get a darker background.                                                                                         |
 | tokyonight_colors                   | `{}`      | You can override specific color groups to use other groups or a hex color                                                                                       |
 | tokyonight_day_brightness           | `0.3`     | Adjusts the brightness of the colors of the **Day** style. Number between 0 and 1, from dull to vibrant colors                                                  |

--- a/lua/tokyonight/colors.lua
+++ b/lua/tokyonight/colors.lua
@@ -74,9 +74,10 @@ function M.setup(config)
   colors.bg_popup = colors.bg_dark
   colors.bg_statusline = colors.bg_dark
 
-  -- Sidebar and Floats are configurable
+  -- Sidebar, Floats and Inactive Buffers are configurable
   colors.bg_sidebar = (config.transparentSidebar and colors.none) or config.darkSidebar and colors.bg_dark or colors.bg
   colors.bg_float = config.darkFloat and colors.bg_dark or colors.bg
+  colors.bg_inactive = config.darkInactive and colors.bg_dark or colors.bg
 
   colors.bg_visual = util.darken(colors.blue0, 0.7)
   colors.bg_search = colors.blue0

--- a/lua/tokyonight/config.lua
+++ b/lua/tokyonight/config.lua
@@ -30,6 +30,7 @@ config = {
   dev = opt("dev", false),
   darkFloat = opt("dark_float", true),
   darkSidebar = opt("dark_sidebar", true),
+  darkInactive = opt("dark_inactive", false),
   transparentSidebar = opt("transparent_sidebar", false),
   transform_colors = false,
   lualineBold = opt("lualine_bold", false),

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -47,7 +47,7 @@ function M.setup(config)
     MoreMsg = { fg = c.blue }, -- |more-prompt|
     NonText = { fg = c.dark3 }, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
     Normal = { fg = c.fg, bg = config.transparent and c.none or c.bg }, -- normal text
-    NormalNC = { fg = c.fg, bg = config.transparent and c.none or c.bg }, -- normal text in non-current windows
+    NormalNC = { fg = c.fg, bg = c.bg_inactive }, -- normal text in non-current windows
     NormalSB = { fg = c.fg_sidebar, bg = c.bg_sidebar }, -- normal text in non-current windows
     NormalFloat = { fg = c.fg, bg = c.bg_float }, -- Normal text in floating windows.
     FloatBorder = { fg = c.border_highlight, bg = c.bg_float },


### PR DESCRIPTION
Hello,

Allow `bg_dark` on inactive buffers.
It's easier to quickly find what window we are working on during a split screen.
The default option is set to false.

![image](https://user-images.githubusercontent.com/32210943/172397628-1d681561-9fcd-4dc1-bce4-db13d06a4157.png)

PS: adjustments will surely be necessary for gutter/sign bar.