### PR TITLE
Add explicit support for 'mini.nvim'

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A dark and light Neovim theme written in Lua ported from the Visual Studio Code 
 - [vim-sneak](https://github.com/justinmk/vim-sneak)
 - [Fern](https://github.com/lambdalisue/fern.vim)
 - [Barbar](https://github.com/romgrk/barbar.nvim)
+- [Mini](https://github.com/echasnovski/mini.nvim)
 
 ## ⚡️ Requirements
 

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -457,6 +457,57 @@ function M.setup(config)
     CmpItemKindEnumMember = { fg = c.green1, bg = c.none },
     CmpItemKindOperator = { fg = c.green1, bg = c.none },
     CmpItemKindSnippet = { fg = c.dark5, bg = c.none },
+
+    -- Mini
+    MiniCompletionActiveParameter = { style = "underline" },
+
+    MiniCursorword = { bg = c.fg_gutter },
+    MiniCursorwordCurrent = { bg = c.fg_gutter },
+
+    MiniIndentscopeSymbol = { fg = c.blue1 },
+    MiniIndentscopePrefix = { style = "nocombine" }, -- Make it invisible
+
+    MiniJump = { fg = c.bg_highlight, bg = c.magenta },
+
+    MiniJump2dSpot = { fg = c.magenta2, style = "bold,nocombine" },
+
+    MiniStarterCurrent = { style = "nocombine" },
+    MiniStarterFooter = { fg = c.yellow, style = "italic" },
+    MiniStarterHeader = { fg = c.blue },
+    MiniStarterInactive = { fg = c.comment, style = config.commentStyle },
+    MiniStarterItem = { fg = c.fg, bg = config.transparent and c.none or c.bg },
+    MiniStarterItemBullet = { fg = c.border_highlight },
+    MiniStarterItemPrefix = { fg = c.warning },
+    MiniStarterSection = {  fg = c.blue1 },
+    MiniStarterQuery = { fg = c.info },
+
+    MiniStatuslineDevinfo = { fg = c.fg_dark, bg = c.bg_highlight },
+    MiniStatuslineFileinfo = { fg = c.fg_dark, bg = c.bg_highlight },
+    MiniStatuslineFilename = { fg = c.fg_dark, bg = c.fg_gutter },
+    MiniStatuslineInactive = { fg = c.blue, bg = c.bg_statusline },
+    MiniStatuslineModeCommand = { fg = c.black, bg = c.yellow, style = "bold" },
+    MiniStatuslineModeInsert = { fg = c.black, bg = c.green, style = "bold" },
+    MiniStatuslineModeNormal = { fg = c.black, bg = c.blue, style = "bold" },
+    MiniStatuslineModeOther = { fg = c.black, bg = c.teal, style = "bold" },
+    MiniStatuslineModeReplace = { fg = c.black, bg = c.red, style = "bold" },
+    MiniStatuslineModeVisual = { fg = c.black, bg = c.magenta, style = "bold" },
+
+    MiniSurround = { bg = c.orange, fg = c.black },
+
+    MiniTablineCurrent = { fg = c.fg, bg = c.fg_gutter },
+    MiniTablineFill = { bg = c.black },
+    MiniTablineHidden = { fg = c.dark5, bg = c.bg_statusline },
+    MiniTablineModifiedCurrent = { fg = c.warning, bg = c.fg_gutter },
+    MiniTablineModifiedHidden = { bg = c.bg_statusline, fg = util.darken(c.warning, 0.7) },
+    MiniTablineModifiedVisible = { fg = c.warning, bg = c.bg_statusline },
+    MiniTablineTabpagesection = { bg = c.bg_statusline, fg = c.none },
+    MiniTablineVisible = { fg = c.fg, bg = c.bg_statusline },
+
+    MiniTestEmphasis = { style = "bold" },
+    MiniTestFail = { fg = c.red, style = "bold"},
+    MiniTestPass = { fg = c.green, style = "bold"},
+
+    MiniTrailspace = { bg = c.red },
   }
 
   theme.defer = {}
@@ -471,6 +522,9 @@ function M.setup(config)
     for _, section in ipairs({ "a", "b", "c" }) do
       theme.defer["lualine_" .. section .. "_inactive"] = inactive
     end
+
+    -- mini.statusline
+    theme.plugins.MiniStatuslineInactive = inactive
   end
 
   return theme


### PR DESCRIPTION
Hi! I would like to add explicit support for [mini.nvim](https://github.com/echasnovski/mini.nvim).

Basic choices are taken from highlight groups to which 'mini.nvim' makes links by default or from analogous plugins.

Differences from default linked groups:
- 'mini.cursorword' is based on 'Illuminate'.
- 'mini.jump' is based on 'Sneak'.
- 'mini.jump2d' is based on 'Hop'. Using `nocombine = true` to be consistent (not have italic labels on italic text).
- 'mini.starter' is based on 'dashboard.lua', 'whichkey.lua', 'telescope.lua', and personal choices:
    - `MiniStarterItemBullet` is as border.
    - `MiniStarterItemPrefix` and `MiniStarterQuery` are based on "warning" and "info" diagnostic colors to be opposite of each other.
    - `MiniStarterSection` is chosen to be visible (as from "Special" highlight group).
- 'mini.statusline' is based on 'lualine/themes/tokyonight.lua' and personal choices:
    - `MiniStatuslineDevinfo` and `MiniStatuslineFileinfo` are "slightly different text".
    - All `MiniStatuslineMode*` have bold text as this seems to be used in screenshot.
    - `MiniStatuslineModeOther` is chosen to be different from others.
- 'mini.tabline' is based on 'Barbar'.
- 'mini.test' has red for fail and green for pass.
- 'mini.trailspace' has group with red background to draw attention.

Before:

https://user-images.githubusercontent.com/24854248/177715941-3a65ed56-7661-4a10-853f-81bd128a9889.mp4

After:

https://user-images.githubusercontent.com/24854248/177715969-f8560bf4-8991-40d5-96cc-a77f6e171b62.mp4