### PR TITLE
Fix on_colors example

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ require("tokyonight").setup({
   },
   sidebars = { "qf", "vista_kind", "terminal", "packer" },
   -- Change the "hint" color to the "orange" color, and make the "error" color bright red
-  on_colors = function(colors) {
+  on_colors = function(colors)
     colors.hint = colors.orange
     colors.error = "#ff0000"
-  }
+  end
 })
 ```
 


### PR DESCRIPTION
There was a syntax error in the documentation, or at least the given example broke my syntax highlighting.