### PR TITLE
feat: add template for iTerm2

### DIFF
--- a/extras/iterm_tokyonight_day.itermcolors
+++ b/extras/iterm_tokyonight_day.itermcolors
@@ -7,221 +7,221 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.92941176891326904</real>
+		<real>0.9294117647058824</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.91372549533843994</real>
+		<real>0.9137254901960784</real>
 		<key>Red Component</key>
-		<real>0.91372549533843994</real>
+		<real>0.9137254901960784</real>
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.3960784375667572</real>
+		<real>0.3960784313725490</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.16470588743686676</real>
+		<real>0.1647058823529412</real>
 		<key>Red Component</key>
-		<real>0.96078431606292725</real>
+		<real>0.9607843137254902</real>
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.22352941334247589</real>
+		<real>0.2235294117647059</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.45882353186607361</real>
+		<real>0.4588235294117647</real>
 		<key>Red Component</key>
-		<real>0.34509804844856262</real>
+		<real>0.3450980392156863</real>
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.24313725531101227</real>
+		<real>0.2431372549019608</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.42352941632270813</real>
+		<real>0.4235294117647059</real>
 		<key>Red Component</key>
-		<real>0.54901963472366333</real>
+		<real>0.5490196078431373</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.91372549533843994</real>
+		<real>0.9137254901960784</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.49019607901573181</real>
+		<real>0.4901960784313725</real>
 		<key>Red Component</key>
-		<real>0.18039216101169586</real>
+		<real>0.1803921568627451</real>
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.94509804248809814</real>
+		<real>0.9450980392156862</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.32941177487373352</real>
+		<real>0.3294117647058823</real>
 		<key>Red Component</key>
-		<real>0.59607845544815063</real>
+		<real>0.5960784313725490</real>
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.59215688705444336</real>
+		<real>0.5921568627450980</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.44313725829124451</real>
+		<real>0.4431372549019608</real>
 		<key>Red Component</key>
-		<real>0.0</real>
+		<real>0.0000000000000000</real>
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.74901962280273438</real>
+		<real>0.7490196078431373</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.37647059559822083</real>
+		<real>0.3764705882352941</real>
 		<key>Red Component</key>
-		<real>0.21568627655506134</real>
+		<real>0.2156862745098039</real>
 	</dict>
 	<key>Ansi 2 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.22352941334247589</real>
+		<real>0.2235294117647059</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.45882353186607361</real>
+		<real>0.4588235294117647</real>
 		<key>Red Component</key>
-		<real>0.34509804844856262</real>
+		<real>0.3450980392156863</real>
 	</dict>
 	<key>Ansi 3 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.24313725531101227</real>
+		<real>0.2431372549019608</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.42352941632270813</real>
+		<real>0.4235294117647059</real>
 		<key>Red Component</key>
-		<real>0.54901963472366333</real>
+		<real>0.5490196078431373</real>
 	</dict>
 	<key>Ansi 4 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.91372549533843994</real>
+		<real>0.9137254901960784</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.49019607901573181</real>
+		<real>0.4901960784313725</real>
 		<key>Red Component</key>
-		<real>0.18039216101169586</real>
+		<real>0.1803921568627451</real>
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.94509804248809814</real>
+		<real>0.9450980392156862</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.32941177487373352</real>
+		<real>0.3294117647058823</real>
 		<key>Red Component</key>
-		<real>0.59607845544815063</real>
+		<real>0.5960784313725490</real>
 	</dict>
 	<key>Ansi 6 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.59215688705444336</real>
+		<real>0.5921568627450980</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.44313725829124451</real>
+		<real>0.4431372549019608</real>
 		<key>Red Component</key>
-		<real>0.0</real>
+		<real>0.0000000000000000</real>
 	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.69019609689712524</real>
+		<real>0.6901960784313725</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.44705882668495178</real>
+		<real>0.4470588235294118</real>
 		<key>Red Component</key>
-		<real>0.3803921639919281</real>
+		<real>0.3803921568627451</real>
 	</dict>
 	<key>Ansi 8 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.77254903316497803</real>
+		<real>0.7725490196078432</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.65098041296005249</real>
+		<real>0.6509803921568628</real>
 		<key>Red Component</key>
-		<real>0.63137257099151611</real>
+		<real>0.6313725490196078</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.3960784375667572</real>
+		<real>0.3960784313725490</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.16470588743686676</real>
+		<real>0.1647058823529412</real>
 		<key>Red Component</key>
-		<real>0.96078431606292725</real>
+		<real>0.9607843137254902</real>
 	</dict>
 	<key>Background Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.90588235855102539</real>
+		<real>0.9058823529411765</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.88627451658248901</real>
+		<real>0.8862745098039215</real>
 		<key>Red Component</key>
-		<real>0.88235294818878174</real>
+		<real>0.8823529411764706</real>
 	</dict>
 	<key>Badge Color</key>
 	<dict>
@@ -241,104 +241,104 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.93333333730697632</real>
+		<real>0.4549019607843137</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.93333333730697632</real>
+		<real>0.5490196078431373</real>
 		<key>Red Component</key>
-		<real>0.93333333730697632</real>
+		<real>0.0666666666666667</real>
 	</dict>
 	<key>Cursor Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.74901962280273438</real>
+		<real>0.7490196078431373</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.37647059559822083</real>
+		<real>0.3764705882352941</real>
 		<key>Red Component</key>
-		<real>0.21568627655506134</real>
+		<real>0.2156862745098039</real>
 	</dict>
 	<key>Cursor Guide Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>0.25</real>
 		<key>Blue Component</key>
-		<real>1</real>
+		<real>0.7490196078431373</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.9268307089805603</real>
+		<real>0.3764705882352941</real>
 		<key>Red Component</key>
-		<real>0.70213186740875244</real>
+		<real>0.2156862745098039</real>
 	</dict>
 	<key>Cursor Text Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.90588235855102539</real>
+		<real>0.9058823529411765</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.88627451658248901</real>
+		<real>0.8862745098039215</real>
 		<key>Red Component</key>
-		<real>0.88235294818878174</real>
+		<real>0.8823529411764706</real>
 	</dict>
 	<key>Foreground Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.74901962280273438</real>
+		<real>0.7490196078431373</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.37647059559822083</real>
+		<real>0.3764705882352941</real>
 		<key>Red Component</key>
-		<real>0.21568627655506134</real>
+		<real>0.2156862745098039</real>
 	</dict>
 	<key>Link Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.7921568751335144</real>
+		<real>0.4078431372549020</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.85490196943283081</real>
+		<real>0.4392156862745098</real>
 		<key>Red Component</key>
-		<real>0.45098039507865906</real>
+		<real>0.2196078431372549</real>
 	</dict>
 	<key>Selected Text Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.74901962280273438</real>
+		<real>0.7490196078431373</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.37647059559822083</real>
+		<real>0.3764705882352941</real>
 		<key>Red Component</key>
-		<real>0.21568627655506134</real>
+		<real>0.2156862745098039</real>
 	</dict>
 	<key>Selection Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.87450981140136719</real>
+		<real>0.8745098039215686</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.65490198135375977</real>
+		<real>0.6549019607843137</real>
 		<key>Red Component</key>
-		<real>0.60000002384185791</real>
+		<real>0.6000000000000000</real>
 	</dict>
 </dict>
 </plist>

--- a/extras/iterm_tokyonight_storm.itermcolors
+++ b/extras/iterm_tokyonight_storm.itermcolors
@@ -7,221 +7,221 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.18431372940540314</real>
+		<real>0.1843137254901961</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.12549020349979401</real>
+		<real>0.1254901960784314</real>
 		<key>Red Component</key>
-		<real>0.11372549086809158</real>
+		<real>0.1137254901960784</real>
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.55686277151107788</real>
+		<real>0.5568627450980392</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.46274510025978088</real>
+		<real>0.4627450980392157</real>
 		<key>Red Component</key>
-		<real>0.9686274528503418</real>
+		<real>0.9686274509803922</real>
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.41568627953529358</real>
+		<real>0.4156862745098039</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.80784314870834351</real>
+		<real>0.8078431372549020</real>
 		<key>Red Component</key>
-		<real>0.61960786581039429</real>
+		<real>0.6196078431372549</real>
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.40784314274787903</real>
+		<real>0.4078431372549020</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.68627452850341797</real>
+		<real>0.6862745098039216</real>
 		<key>Red Component</key>
-		<real>0.87843137979507446</real>
+		<real>0.8784313725490196</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.9686274528503418</real>
+		<real>0.9686274509803922</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.63529413938522339</real>
+		<real>0.6352941176470588</real>
 		<key>Red Component</key>
-		<real>0.47843137383460999</real>
+		<real>0.4784313725490196</real>
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.9686274528503418</real>
+		<real>0.9686274509803922</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.60392159223556519</real>
+		<real>0.6039215686274509</real>
 		<key>Red Component</key>
-		<real>0.73333334922790527</real>
+		<real>0.7333333333333333</real>
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>1</real>
+		<real>1.0000000000000000</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.81176471710205078</real>
+		<real>0.8117647058823529</real>
 		<key>Red Component</key>
-		<real>0.49019607901573181</real>
+		<real>0.4901960784313725</real>
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.96078431606292725</real>
+		<real>0.9607843137254902</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.7921568751335144</real>
+		<real>0.7921568627450980</real>
 		<key>Red Component</key>
-		<real>0.75294119119644165</real>
+		<real>0.7529411764705882</real>
 	</dict>
 	<key>Ansi 2 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.41568627953529358</real>
+		<real>0.4156862745098039</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.80784314870834351</real>
+		<real>0.8078431372549020</real>
 		<key>Red Component</key>
-		<real>0.61960786581039429</real>
+		<real>0.6196078431372549</real>
 	</dict>
 	<key>Ansi 3 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.40784314274787903</real>
+		<real>0.4078431372549020</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.68627452850341797</real>
+		<real>0.6862745098039216</real>
 		<key>Red Component</key>
-		<real>0.87843137979507446</real>
+		<real>0.8784313725490196</real>
 	</dict>
 	<key>Ansi 4 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.9686274528503418</real>
+		<real>0.9686274509803922</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.63529413938522339</real>
+		<real>0.6352941176470588</real>
 		<key>Red Component</key>
-		<real>0.47843137383460999</real>
+		<real>0.4784313725490196</real>
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.9686274528503418</real>
+		<real>0.9686274509803922</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.60392159223556519</real>
+		<real>0.6039215686274509</real>
 		<key>Red Component</key>
-		<real>0.73333334922790527</real>
+		<real>0.7333333333333333</real>
 	</dict>
 	<key>Ansi 6 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>1</real>
+		<real>1.0000000000000000</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.81176471710205078</real>
+		<real>0.8117647058823529</real>
 		<key>Red Component</key>
-		<real>0.49019607901573181</real>
+		<real>0.4901960784313725</real>
 	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.83921569585800171</real>
+		<real>0.8392156862745098</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.69411766529083252</real>
+		<real>0.6941176470588235</real>
 		<key>Red Component</key>
-		<real>0.66274511814117432</real>
+		<real>0.6627450980392157</real>
 	</dict>
 	<key>Ansi 8 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.40784314274787903</real>
+		<real>0.4078431372549020</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.28235295414924622</real>
+		<real>0.2823529411764706</real>
 		<key>Red Component</key>
-		<real>0.25490197539329529</real>
+		<real>0.2549019607843137</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.55686277151107788</real>
+		<real>0.5568627450980392</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.46274510025978088</real>
+		<real>0.4627450980392157</real>
 		<key>Red Component</key>
-		<real>0.9686274528503418</real>
+		<real>0.9686274509803922</real>
 	</dict>
 	<key>Background Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.23137255012989044</real>
+		<real>0.2313725490196079</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.15686275064945221</real>
+		<real>0.1568627450980392</real>
 		<key>Red Component</key>
-		<real>0.14117647707462311</real>
+		<real>0.1411764705882353</real>
 	</dict>
 	<key>Badge Color</key>
 	<dict>
@@ -241,104 +241,104 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.93333333730697632</real>
+		<real>0.6117647058823530</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.93333333730697632</real>
+		<real>0.7372549019607844</real>
 		<key>Red Component</key>
-		<real>0.93333333730697632</real>
+		<real>0.1019607843137255</real>
 	</dict>
 	<key>Cursor Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.96078431606292725</real>
+		<real>0.9607843137254902</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.7921568751335144</real>
+		<real>0.7921568627450980</real>
 		<key>Red Component</key>
-		<real>0.75294119119644165</real>
+		<real>0.7529411764705882</real>
 	</dict>
 	<key>Cursor Guide Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>0.25</real>
 		<key>Blue Component</key>
-		<real>1</real>
+		<real>0.9607843137254902</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.9268307089805603</real>
+		<real>0.7921568627450980</real>
 		<key>Red Component</key>
-		<real>0.70213186740875244</real>
+		<real>0.7529411764705882</real>
 	</dict>
 	<key>Cursor Text Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.18431372940540314</real>
+		<real>0.2313725490196079</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.12549020349979401</real>
+		<real>0.1568627450980392</real>
 		<key>Red Component</key>
-		<real>0.11372549086809158</real>
+		<real>0.1411764705882353</real>
 	</dict>
 	<key>Foreground Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.96078431606292725</real>
+		<real>0.9607843137254902</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.7921568751335144</real>
+		<real>0.7921568627450980</real>
 		<key>Red Component</key>
-		<real>0.75294119119644165</real>
+		<real>0.7529411764705882</real>
 	</dict>
 	<key>Link Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.7921568751335144</real>
+		<real>0.7921568627450980</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.85490196943283081</real>
+		<real>0.8549019607843137</real>
 		<key>Red Component</key>
-		<real>0.45098039507865906</real>
+		<real>0.4509803921568628</real>
 	</dict>
 	<key>Selected Text Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.96078431606292725</real>
+		<real>0.9607843137254902</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.7921568751335144</real>
+		<real>0.7921568627450980</real>
 		<key>Red Component</key>
-		<real>0.75294119119644165</real>
+		<real>0.7529411764705882</real>
 	</dict>
 	<key>Selection Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.50980395078659058</real>
+		<real>0.5098039215686274</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.29019609093666077</real>
+		<real>0.2901960784313726</real>
 		<key>Red Component</key>
-		<real>0.21176470816135406</real>
+		<real>0.2117647058823529</real>
 	</dict>
 </dict>
 </plist>

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -22,6 +22,7 @@ function M.setup()
     xfceterm = "theme",
     foot = "ini",
     tilix = "json",
+    iterm = "itermcolors",
   }
   -- map of style to style name
   local styles = {

--- a/lua/tokyonight/extra/iterm.lua
+++ b/lua/tokyonight/extra/iterm.lua
@@ -1,3 +1,27 @@
+local function get_component(hex, component)
+  hex = hex:gsub("#", "")
+  local num
+  if component == "r" then
+    num = tonumber("0x" .. hex:sub(1, 2)) / 255
+  elseif component == "g" then
+    num = tonumber("0x" .. hex:sub(3, 4)) / 255
+  elseif component == "b" then
+    num = tonumber("0x" .. hex:sub(5, 6)) / 255
+  end
+  return string.format("%.16f", num)
+end
+
+local function template(str, table)
+  return (str:gsub("($%b{})", function(w)
+    return get_component(table[w:sub(3, -4)], w:sub(-2, -2))
+  end))
+end
+
+local M = {}
+
+function M.generate(colors)
+
+  local iterm = template([[
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -7,221 +31,221 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.1176470588235294</real>
+		<real>${black.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.0862745098039216</real>
+		<real>${black.g}</real>
 		<key>Red Component</key>
-		<real>0.0823529411764706</real>
+		<real>${black.r}</real>
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.5568627450980392</real>
+		<real>${red.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.4627450980392157</real>
+		<real>${red.g}</real>
 		<key>Red Component</key>
-		<real>0.9686274509803922</real>
+		<real>${red.r}</real>
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.4156862745098039</real>
+		<real>${green.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.8078431372549020</real>
+		<real>${green.g}</real>
 		<key>Red Component</key>
-		<real>0.6196078431372549</real>
+		<real>${green.r}</real>
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.4078431372549020</real>
+		<real>${yellow.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.6862745098039216</real>
+		<real>${yellow.g}</real>
 		<key>Red Component</key>
-		<real>0.8784313725490196</real>
+		<real>${yellow.r}</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.9686274509803922</real>
+		<real>${blue.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.6352941176470588</real>
+		<real>${blue.g}</real>
 		<key>Red Component</key>
-		<real>0.4784313725490196</real>
+		<real>${blue.r}</real>
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.9686274509803922</real>
+		<real>${magenta.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.6039215686274509</real>
+		<real>${magenta.g}</real>
 		<key>Red Component</key>
-		<real>0.7333333333333333</real>
+		<real>${magenta.r}</real>
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>1.0000000000000000</real>
+		<real>${cyan.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.8117647058823529</real>
+		<real>${cyan.g}</real>
 		<key>Red Component</key>
-		<real>0.4901960784313725</real>
+		<real>${cyan.r}</real>
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.9607843137254902</real>
+		<real>${fg.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.7921568627450980</real>
+		<real>${fg.g}</real>
 		<key>Red Component</key>
-		<real>0.7529411764705882</real>
+		<real>${fg.r}</real>
 	</dict>
 	<key>Ansi 2 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.4156862745098039</real>
+		<real>${green.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.8078431372549020</real>
+		<real>${green.g}</real>
 		<key>Red Component</key>
-		<real>0.6196078431372549</real>
+		<real>${green.r}</real>
 	</dict>
 	<key>Ansi 3 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.4078431372549020</real>
+		<real>${yellow.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.6862745098039216</real>
+		<real>${yellow.g}</real>
 		<key>Red Component</key>
-		<real>0.8784313725490196</real>
+		<real>${yellow.r}</real>
 	</dict>
 	<key>Ansi 4 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.9686274509803922</real>
+		<real>${blue.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.6352941176470588</real>
+		<real>${blue.g}</real>
 		<key>Red Component</key>
-		<real>0.4784313725490196</real>
+		<real>${blue.r}</real>
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.9686274509803922</real>
+		<real>${magenta.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.6039215686274509</real>
+		<real>${magenta.g}</real>
 		<key>Red Component</key>
-		<real>0.7333333333333333</real>
+		<real>${magenta.r}</real>
 	</dict>
 	<key>Ansi 6 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>1.0000000000000000</real>
+		<real>${cyan.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.8117647058823529</real>
+		<real>${cyan.g}</real>
 		<key>Red Component</key>
-		<real>0.4901960784313725</real>
+		<real>${cyan.r}</real>
 	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.8392156862745098</real>
+		<real>${fg_dark.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.6941176470588235</real>
+		<real>${fg_dark.g}</real>
 		<key>Red Component</key>
-		<real>0.6627450980392157</real>
+		<real>${fg_dark.r}</real>
 	</dict>
 	<key>Ansi 8 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.4078431372549020</real>
+		<real>${terminal_black.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.2823529411764706</real>
+		<real>${terminal_black.g}</real>
 		<key>Red Component</key>
-		<real>0.2549019607843137</real>
+		<real>${terminal_black.r}</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.5568627450980392</real>
+		<real>${red.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.4627450980392157</real>
+		<real>${red.g}</real>
 		<key>Red Component</key>
-		<real>0.9686274509803922</real>
+		<real>${red.r}</real>
 	</dict>
 	<key>Background Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.1490196078431373</real>
+		<real>${bg.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.1058823529411765</real>
+		<real>${bg.g}</real>
 		<key>Red Component</key>
-		<real>0.1019607843137255</real>
+		<real>${bg.r}</real>
 	</dict>
 	<key>Badge Color</key>
 	<dict>
@@ -241,104 +265,111 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.6117647058823530</real>
+		<real>${teal.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.7372549019607844</real>
+		<real>${teal.g}</real>
 		<key>Red Component</key>
-		<real>0.1019607843137255</real>
+		<real>${teal.r}</real>
 	</dict>
 	<key>Cursor Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.9607843137254902</real>
+		<real>${fg.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.7921568627450980</real>
+		<real>${fg.g}</real>
 		<key>Red Component</key>
-		<real>0.7529411764705882</real>
+		<real>${fg.r}</real>
 	</dict>
 	<key>Cursor Guide Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>0.25</real>
 		<key>Blue Component</key>
-		<real>0.9607843137254902</real>
+		<real>${fg.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.7921568627450980</real>
+		<real>${fg.g}</real>
 		<key>Red Component</key>
-		<real>0.7529411764705882</real>
+		<real>${fg.r}</real>
 	</dict>
 	<key>Cursor Text Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.1490196078431373</real>
+		<real>${bg.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.1058823529411765</real>
+		<real>${bg.g}</real>
 		<key>Red Component</key>
-		<real>0.1019607843137255</real>
+		<real>${bg.r}</real>
 	</dict>
 	<key>Foreground Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.9607843137254902</real>
+		<real>${fg.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.7921568627450980</real>
+		<real>${fg.g}</real>
 		<key>Red Component</key>
-		<real>0.7529411764705882</real>
+		<real>${fg.r}</real>
 	</dict>
 	<key>Link Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.7921568627450980</real>
+		<real>${green1.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.8549019607843137</real>
+		<real>${green1.g}</real>
 		<key>Red Component</key>
-		<real>0.4509803921568628</real>
+		<real>${green1.r}</real>
 	</dict>
 	<key>Selected Text Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.9607843137254902</real>
+		<real>${fg.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.7921568627450980</real>
+		<real>${fg.g}</real>
 		<key>Red Component</key>
-		<real>0.7529411764705882</real>
+		<real>${fg.r}</real>
 	</dict>
 	<key>Selection Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.4862745098039216</real>
+		<real>${bg_visual.b}</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.2745098039215687</real>
+		<real>${bg_visual.g}</real>
 		<key>Red Component</key>
-		<real>0.2000000000000000</real>
+		<real>${bg_visual.r}</real>
 	</dict>
 </dict>
-</plist>
+</plist>]],
+    colors
+  )
+  return iterm
+end
+
+return M
+-- vim: sw=2


### PR DESCRIPTION
Currently, the theme of iTerm2 is not generated automatically. Besides the bold color #118 and link color of `tokyonight-day` is hard to recognized.

This PR create template for iTerm2 theme based on:
```
Background Color: bg
Foreground Color: fg
Selection Color: bg_visual
Selected Text Color: fg
Cursor Color: fg
Cursor Guide Color: fg with alpha 0.25 (changed)
Cursor Text Color: bg
Link Color: green1 (changed)
Bold Color: teal (changed)

Ansi 0 Color: black
Ansi 1 Color: red
Ansi 2 Color: green
Ansi 3 Color: yellow
Ansi 4 Color: blue
Ansi 5 Color: magenta
Ansi 6 Color: cyan
Ansi 7 Color: fg_dark

Ansi 8 Color: terminal_black
Ansi 9 Color: red
Ansi 10 Color: green
Ansi 11 Color: yellow
Ansi 12 Color: blue
Ansi 13 Color: magenta
Ansi 14 Color: cyan
Ansi 15 Color: fg
```
I don't know which colors is used for Cursor Guide Color,  Link Color, and Bold Color. I think those colors may not color in this theme, thus I replaced them. And the #118 should be fixed.

Beside, there are some small differences for colors not replaced. I'm not sure the reason.