### PR TITLE
fix: add fish pager selection color

### DIFF
--- a/lua/tokyonight/extra/fish.lua
+++ b/lua/tokyonight/extra/fish.lua
@@ -24,7 +24,7 @@ function M.generate(colors)
     set -l purple ${purple}
     set -l cyan ${cyan}
     set -l pink ${magenta}
-    
+
     # Syntax Highlighting Colors
     set -g fish_color_normal $foreground
     set -g fish_color_command $cyan
@@ -40,13 +40,14 @@ function M.generate(colors)
     set -g fish_color_operator $green
     set -g fish_color_escape $pink
     set -g fish_color_autosuggestion $comment
-    
+
     # Completion Pager Colors
     set -g fish_pager_color_progress $comment
     set -g fish_pager_color_prefix $cyan
     set -g fish_pager_color_completion $foreground
     set -g fish_pager_color_description $comment
-    
+    set -g fish_pager_color_selected_background --background=$selection
+
   ]],
     fishColors
   )


### PR DESCRIPTION
Before:

![tokyo-pager-select-before](https://user-images.githubusercontent.com/5426924/191945131-2574645b-a9f6-409d-91dd-d2e15860fa2b.png)

After:

![tokyo-pager-select-after](https://user-images.githubusercontent.com/5426924/191944224-5810f816-f2ee-4637-91a1-ef74c722c612.png)

This surprised me. Either my setup behaves differently, or the users who contributed this don't actually use fish.

p.s. I didn't regenerate the extras in the PR.