### PR TITLE
nvim-tree: handle white separator on transparent sidebar

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -316,7 +316,7 @@ function M.setup()
 
     -- NvimTree
     NvimTreeNormal = { fg = c.fg_sidebar, bg = c.bg_sidebar },
-    NvimTreeVertSplit = { fg = c.bg_sidebar, bg = c.bg_sidebar },
+    NvimTreeWinSeparator = { fg = options.styles.sidebars == "transparent" and c.border or c.bg_sidebar, bg = c.bg_sidebar },
     NvimTreeNormalNC = { fg = c.fg_sidebar, bg = c.bg_sidebar },
     NvimTreeRootFolder = { fg = c.blue, bold = true },
     NvimTreeGitDirty = { fg = c.git.change },


### PR DESCRIPTION
- change `NvimTreeVertSplit` to `NvimTreeWinSeparator` since the former is deprecated. 
 https://github.com/kyazdani42/nvim-tree.lua/pull/1225
- set `NvimTreeWinSeparator` to `border` if sidebar style is `transparent`