### PR TITLE
feat: add options light_style

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ require("tokyonight").setup({
   -- your configuration comes here
   -- or leave it empty to use the default settings
   style = "storm", -- The theme comes in three styles, `storm`, `moon`, a darker variant `night` and `day`
+  light_style = "day", -- The theme is used when the background is set to light
   transparent = false, -- Enable this to disable setting the background color
   terminal_colors = true, -- Configure the colors used when opening a `:terminal` in Neovim
   styles = {

--- a/lua/tokyonight/colors.lua
+++ b/lua/tokyonight/colors.lua
@@ -99,7 +99,8 @@ function M.setup(opts)
   opts = opts or {}
   local config = require("tokyonight.config")
 
-  local palette = M[config.options.style] or {}
+  local style = config.is_day() and config.options.light_style or config.options.style
+  local palette = M[style] or {}
   if type(palette) == "function" then
     palette = palette()
   end

--- a/lua/tokyonight/config.lua
+++ b/lua/tokyonight/config.lua
@@ -5,6 +5,7 @@ local M = {}
 ---@field on_highlights fun(highlights: Highlights, colors: ColorScheme)
 local defaults = {
   style = "storm", -- The theme comes in three styles, `storm`, a darker variant `night` and `day`
+  light_style = "day", -- The theme is used when the background is set to light
   transparent = false, -- Enable this to disable setting the background color
   terminal_colors = true, -- Configure the colors used when opening a `:terminal` in Neovim
   styles = {


### PR DESCRIPTION
Specify style when `background=light` by `light_style` #230. If the `light_style` is not set, it will fallback to `style`. I thinks we can set the default value of `light_style` to `day`, because in README:
> The day style will be used if:
>
> `{ style = "day"}` was passed to `setup(options)`
> or `vim.o.background = "light"`

but currently it is actually not since 9bc8f4e, addressed in #223.