### PR TITLE
feat: add tmux-prefix-highlight support

### DIFF
--- a/extras/tmux/tokyonight_day.tmux
+++ b/extras/tmux/tokyonight_day.tmux
@@ -29,4 +29,7 @@ setw -g window-status-separator ""
 setw -g window-status-style "NONE,fg=#6172b0,bg=#e9e9ec"
 setw -g window-status-format "#[fg=#e9e9ec,bg=#e9e9ec,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#e9e9ec,bg=#e9e9ec,nobold,nounderscore,noitalics]"
 setw -g window-status-current-format "#[fg=#e9e9ec,bg=#a8aecb,nobold,nounderscore,noitalics]#[fg=#2e7de9,bg=#a8aecb,bold] #I  #W #F #[fg=#a8aecb,bg=#e9e9ec,nobold,nounderscore,noitalics]"
-  
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#8c6c3e]#[bg=#e9e9ec]#[fg=#e9e9ec]#[bg=#8c6c3e]"
+set -g @prefix_highlight_output_suffix ""

--- a/extras/tmux/tokyonight_moon.tmux
+++ b/extras/tmux/tokyonight_moon.tmux
@@ -29,4 +29,7 @@ setw -g window-status-separator ""
 setw -g window-status-style "NONE,fg=#828bb8,bg=#1e2030"
 setw -g window-status-format "#[fg=#1e2030,bg=#1e2030,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#1e2030,bg=#1e2030,nobold,nounderscore,noitalics]"
 setw -g window-status-current-format "#[fg=#1e2030,bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#3b4261,bold] #I  #W #F #[fg=#3b4261,bg=#1e2030,nobold,nounderscore,noitalics]"
-  
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#ffc777]#[bg=#1e2030]#[fg=#1e2030]#[bg=#ffc777]"
+set -g @prefix_highlight_output_suffix ""

--- a/extras/tmux/tokyonight_night.tmux
+++ b/extras/tmux/tokyonight_night.tmux
@@ -29,4 +29,7 @@ setw -g window-status-separator ""
 setw -g window-status-style "NONE,fg=#a9b1d6,bg=#16161e"
 setw -g window-status-format "#[fg=#16161e,bg=#16161e,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#16161e,bg=#16161e,nobold,nounderscore,noitalics]"
 setw -g window-status-current-format "#[fg=#16161e,bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#7aa2f7,bg=#3b4261,bold] #I  #W #F #[fg=#3b4261,bg=#16161e,nobold,nounderscore,noitalics]"
-  
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#e0af68]#[bg=#16161e]#[fg=#16161e]#[bg=#e0af68]"
+set -g @prefix_highlight_output_suffix ""

--- a/extras/tmux/tokyonight_storm.tmux
+++ b/extras/tmux/tokyonight_storm.tmux
@@ -29,4 +29,7 @@ setw -g window-status-separator ""
 setw -g window-status-style "NONE,fg=#a9b1d6,bg=#1f2335"
 setw -g window-status-format "#[fg=#1f2335,bg=#1f2335,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#1f2335,bg=#1f2335,nobold,nounderscore,noitalics]"
 setw -g window-status-current-format "#[fg=#1f2335,bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#7aa2f7,bg=#3b4261,bold] #I  #W #F #[fg=#3b4261,bg=#1f2335,nobold,nounderscore,noitalics]"
-  
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#e0af68]#[bg=#1f2335]#[fg=#1f2335]#[bg=#e0af68]"
+set -g @prefix_highlight_output_suffix ""

--- a/lua/tokyonight/extra/tmux.lua
+++ b/lua/tokyonight/extra/tmux.lua
@@ -37,6 +37,10 @@ setw -g window-status-separator ""
 setw -g window-status-style "${none},fg=${fg_sidebar},bg=${bg_statusline}"
 setw -g window-status-format "#[fg=${bg_statusline},bg=${bg_statusline},nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=${bg_statusline},bg=${bg_statusline},nobold,nounderscore,noitalics]"
 setw -g window-status-current-format "#[fg=${bg_statusline},bg=${fg_gutter},nobold,nounderscore,noitalics]#[fg=${blue},bg=${fg_gutter},bold] #I  #W #F #[fg=${fg_gutter},bg=${bg_statusline},nobold,nounderscore,noitalics]"
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=${yellow}]#[bg=${bg_statusline}]#[fg=${bg_statusline}]#[bg=${yellow}]"
+set -g @prefix_highlight_output_suffix ""
   ]],
     colors
   )


### PR DESCRIPTION
Adds support for [tmux-prefix-highlight] plugin.

[tmux-prefix-highlight]: https://github.com/tmux-plugins/tmux-prefix-highlight

<img width="1330" alt="image" src="https://user-images.githubusercontent.com/38053499/193682405-2465151c-7ac0-4216-b6c2-25ca03b4fcdb.png">
