### PR TITLE
feat: add highlight `LspInfoBorder`

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -192,6 +192,8 @@ function M.setup()
     LspSignatureActiveParameter = { fg = c.orange },
     LspCodeLens = { fg = c.comment },
 
+    LspInfoBorder = { fg = c.border_highlight, bg = c.bg_float },
+
     ALEErrorSign = { fg = c.error },
     ALEWarningSign = { fg = c.warning },
 


### PR DESCRIPTION
The default highlight of `LspInfoBorder` link to `Label`, which lacks a proper bg. Besides I change the fg to `c.border_highlight` which was commonly used for borders.

Before:
<img width="1174" alt="截屏2022-10-05 15 17 46" src="https://user-images.githubusercontent.com/40141251/194004398-09146acc-f7f3-4e66-8b85-48949b7586c4.png">

After:
<img width="1179" alt="截屏2022-10-05 15 17 19" src="https://user-images.githubusercontent.com/40141251/194004416-51470a2e-7529-41e2-a3e9-dce23a629423.png">
