### PR TITLE
feat: added highlights for `nvim-notify`

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -567,6 +567,32 @@ function M.setup()
     YankyPut = { link = "IncSearch" },
     YankyYanked = { link = "IncSearch" },
 
+    -- Notify
+    --- Border
+    NotifyERRORBorder = { fg = util.darken(c.error, 0.3), bg = c.bg_float },
+    NotifyWARNBorder  = { fg = util.darken(c.warning, 0.3), bg = c.bg_float },
+    NotifyINFOBorder  = { fg = util.darken(c.info, 0.3), bg = c.bg_float },
+    NotifyDEBUGBorder = { fg = util.darken(c.comment, 0.3), bg = c.bg_float },
+    NotifyTRACEBorder = { fg = util.darken(c.purple, 0.3), bg = c.bg_float },
+    --- Icons
+    NotifyERRORIcon   = { fg = c.error },
+    NotifyWARNIcon    = { fg = c.warning },
+    NotifyINFOIcon    = { fg = c.info },
+    NotifyDEBUGIcon   = { fg = c.comment },
+    NotifyTRACEIcon   = { fg = c.purple },
+    --- Title
+    NotifyERRORTitle  = { fg = c.error },
+    NotifyWARNTitle   = { fg = c.warning },
+    NotifyINFOTitle   = { fg = c.info },
+    NotifyDEBUGTitle  = { fg = c.comment },
+    NotifyTRACETitle  = { fg = c.purple },
+    --- Body
+    NotifyERRORBody   = { fg = c.fg, bg = c.bg_float },
+    NotifyWARNBody    = { fg = c.fg, bg = c.bg_float },
+    NotifyINFOBody    = { fg = c.fg, bg = c.bg_float },
+    NotifyDEBUGBody   = { fg = c.fg, bg = c.bg_float },
+    NotifyTRACEBody   = { fg = c.fg, bg = c.bg_float },
+
     -- Mini
     MiniCompletionActiveParameter = { underline = true },
 

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -569,11 +569,11 @@ function M.setup()
 
     -- Notify
     --- Border
-    NotifyERRORBorder = { fg = util.darken(c.error, 0.3), bg = c.bg_float },
-    NotifyWARNBorder  = { fg = util.darken(c.warning, 0.3), bg = c.bg_float },
-    NotifyINFOBorder  = { fg = util.darken(c.info, 0.3), bg = c.bg_float },
-    NotifyDEBUGBorder = { fg = util.darken(c.comment, 0.3), bg = c.bg_float },
-    NotifyTRACEBorder = { fg = util.darken(c.purple, 0.3), bg = c.bg_float },
+    NotifyERRORBorder = { fg = util.darken(c.error, 0.3), bg = c.bg },
+    NotifyWARNBorder  = { fg = util.darken(c.warning, 0.3), bg = c.bg },
+    NotifyINFOBorder  = { fg = util.darken(c.info, 0.3), bg = c.bg },
+    NotifyDEBUGBorder = { fg = util.darken(c.comment, 0.3), bg = c.bg },
+    NotifyTRACEBorder = { fg = util.darken(c.purple, 0.3), bg = c.bg },
     --- Icons
     NotifyERRORIcon   = { fg = c.error },
     NotifyWARNIcon    = { fg = c.warning },
@@ -587,11 +587,11 @@ function M.setup()
     NotifyDEBUGTitle  = { fg = c.comment },
     NotifyTRACETitle  = { fg = c.purple },
     --- Body
-    NotifyERRORBody   = { fg = c.fg, bg = c.bg_float },
-    NotifyWARNBody    = { fg = c.fg, bg = c.bg_float },
-    NotifyINFOBody    = { fg = c.fg, bg = c.bg_float },
-    NotifyDEBUGBody   = { fg = c.fg, bg = c.bg_float },
-    NotifyTRACEBody   = { fg = c.fg, bg = c.bg_float },
+    NotifyERRORBody   = { fg = c.fg, bg = c.bg },
+    NotifyWARNBody    = { fg = c.fg, bg = c.bg },
+    NotifyINFOBody    = { fg = c.fg, bg = c.bg },
+    NotifyDEBUGBody   = { fg = c.fg, bg = c.bg },
+    NotifyTRACEBody   = { fg = c.fg, bg = c.bg },
 
     -- Mini
     MiniCompletionActiveParameter = { underline = true },


### PR DESCRIPTION
`hightlights` for [nvim-notify](https://github.com/rcarriga/nvim-notify#highlights).

Storm:
<img width="400" alt="截屏2022-10-05 23 41 52" src="https://user-images.githubusercontent.com/40141251/194103159-b0adf1b6-86d2-487e-9fff-40dcfd8893ee.png">

Day:
<img width="400" alt="截屏2022-10-05 23 29 27" src="https://user-images.githubusercontent.com/40141251/194101143-1f0cb937-2508-47d7-8984-6086ae7a5a3b.png">
