### PR TITLE
fix: Make background transparent when nvim-notify is used

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -13,682 +13,682 @@ local M = {}
 
 ---@return Theme
 function M.setup()
-  local config = require("tokyonight.config")
-  local options = config.options
-  ---@class Theme
-  ---@field highlights Highlights
-  local theme = {
-    config = options,
-    colors = colors.setup(),
-  }
-
-  local c = theme.colors
-
-  theme.highlights = {
-    Foo = { bg = c.magenta2, fg = c.magenta2 },
-
-    Comment = { fg = c.comment, style = options.styles.comments }, -- any comment
-    ColorColumn = { bg = c.black }, -- used for the columns set with 'colorcolumn'
-    Conceal = { fg = c.dark5 }, -- placeholder characters substituted for concealed text (see 'conceallevel')
-    Cursor = { fg = c.bg, bg = c.fg }, -- character under the cursor
-    lCursor = { fg = c.bg, bg = c.fg }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
-    CursorIM = { fg = c.bg, bg = c.fg }, -- like Cursor, but used when in IME mode |CursorIM|
-    CursorColumn = { bg = c.bg_highlight }, -- Screen-column at the cursor, when 'cursorcolumn' is set.
-    CursorLine = { bg = c.bg_highlight }, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
-    Directory = { fg = c.blue }, -- directory names (and other special names in listings)
-    DiffAdd = { bg = c.diff.add }, -- diff mode: Added line |diff.txt|
-    DiffChange = { bg = c.diff.change }, -- diff mode: Changed line |diff.txt|
-    DiffDelete = { bg = c.diff.delete }, -- diff mode: Deleted line |diff.txt|
-    DiffText = { bg = c.diff.text }, -- diff mode: Changed text within a changed line |diff.txt|
-    EndOfBuffer = { fg = c.bg }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
-    -- TermCursor  = { }, -- cursor in a focused terminal
-    -- TermCursorNC= { }, -- cursor in an unfocused terminal
-    ErrorMsg = { fg = c.error }, -- error messages on the command line
-    VertSplit = { fg = c.border }, -- the column separating vertically split windows
-    WinSeparator = { fg = c.border, bold = true }, -- the column separating vertically split windows
-    Folded = { fg = c.blue, bg = c.fg_gutter }, -- line used for closed folds
-    FoldColumn = { bg = options.transparent and c.none or c.bg, fg = c.comment }, -- 'foldcolumn'
-    SignColumn = { bg = options.transparent and c.none or c.bg, fg = c.fg_gutter }, -- column where |signs| are displayed
-    SignColumnSB = { bg = c.bg_sidebar, fg = c.fg_gutter }, -- column where |signs| are displayed
-    Substitute = { bg = c.red, fg = c.black }, -- |:substitute| replacement text highlighting
-    LineNr = { fg = c.fg_gutter }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
-    CursorLineNr = { fg = c.dark5 }, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
-    MatchParen = { fg = c.orange, bold = true }, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
-    ModeMsg = { fg = c.fg_dark, bold = true }, -- 'showmode' message (e.g., "-- INSERT -- ")
-    MsgArea = { fg = c.fg_dark }, -- Area for messages and cmdline
-    -- MsgSeparator= { }, -- Separator for scrolled messages, `msgsep` flag of 'display'
-    MoreMsg = { fg = c.blue }, -- |more-prompt|
-    NonText = { fg = c.dark3 }, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
-    Normal = { fg = c.fg, bg = options.transparent and c.none or c.bg }, -- normal text
-    NormalNC = { fg = c.fg, bg = options.transparent and c.none or options.dim_inactive and c.bg_dark or c.bg }, -- normal text in non-current windows
-    NormalSB = { fg = c.fg_sidebar, bg = c.bg_sidebar }, -- normal text in sidebar
-    NormalFloat = { fg = c.fg, bg = c.bg_float }, -- Normal text in floating windows.
-    FloatBorder = { fg = c.border_highlight, bg = c.bg_float },
-    Pmenu = { bg = c.bg_popup, fg = c.fg }, -- Popup menu: normal item.
-    PmenuSel = { bg = util.darken(c.fg_gutter, 0.8) }, -- Popup menu: selected item.
-    PmenuSbar = { bg = util.lighten(c.bg_popup, 0.95) }, -- Popup menu: scrollbar.
-    PmenuThumb = { bg = c.fg_gutter }, -- Popup menu: Thumb of the scrollbar.
-    Question = { fg = c.blue }, -- |hit-enter| prompt and yes/no questions
-    QuickFixLine = { bg = c.bg_visual, bold = true }, -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
-    Search = { bg = c.bg_search, fg = c.fg }, -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.
-    IncSearch = { bg = c.orange, fg = c.black }, -- 'incsearch' highlighting; also used for the text replaced with ":s///c"
-    SpecialKey = { fg = c.dark3 }, -- Unprintable characters: text displayed differently from what it really is.  But not 'listchars' whitespace. |hl-Whitespace|
-    SpellBad = { sp = c.error, undercurl = true }, -- Word that is not recognized by the spellchecker. |spell| Combined with the highlighting used otherwise.
-    SpellCap = { sp = c.warning, undercurl = true }, -- Word that should start with a capital. |spell| Combined with the highlighting used otherwise.
-    SpellLocal = { sp = c.info, undercurl = true }, -- Word that is recognized by the spellchecker as one that is used in another region. |spell| Combined with the highlighting used otherwise.
-    SpellRare = { sp = c.hint, undercurl = true }, -- Word that is recognized by the spellchecker as one that is hardly ever used.  |spell| Combined with the highlighting used otherwise.
-    StatusLine = { fg = c.fg_sidebar, bg = c.bg_statusline }, -- status line of current window
-    StatusLineNC = { fg = c.fg_gutter, bg = c.bg_statusline }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
-    TabLine = { bg = c.bg_statusline, fg = c.fg_gutter }, -- tab pages line, not active tab page label
-    TabLineFill = { bg = c.black }, -- tab pages line, where there are no labels
-    TabLineSel = { fg = c.black, bg = c.blue }, -- tab pages line, active tab page label
-    Title = { fg = c.blue, bold = true }, -- titles for output from ":set all", ":autocmd" etc.
-    Visual = { bg = c.bg_visual }, -- Visual mode selection
-    VisualNOS = { bg = c.bg_visual }, -- Visual mode selection when vim is "Not Owning the Selection".
-    WarningMsg = { fg = c.warning }, -- warning messages
-    Whitespace = { fg = c.fg_gutter }, -- "nbsp", "space", "tab" and "trail" in 'listchars'
-    WildMenu = { bg = c.bg_visual }, -- current match in 'wildmenu' completion
-
-    -- These groups are not listed as default vim groups,
-    -- but they are defacto standard group names for syntax highlighting.
-    -- commented out groups should chain up to their "preferred" group by
-    -- default,
-    -- Uncomment and edit if you want more specific syntax highlighting.
-
-    Constant = { fg = c.orange }, -- (preferred) any constant
-    String = { fg = c.green }, --   a string constant: "this is a string"
-    Character = { fg = c.green }, --  a character constant: 'c', '\n'
-    -- Number        = { }, --   a number constant: 234, 0xff
-    -- Boolean       = { }, --  a boolean constant: TRUE, false
-    -- Float         = { }, --    a floating point constant: 2.3e10
-
-    Identifier = { fg = c.magenta, style = options.styles.variables }, -- (preferred) any variable name
-    Function = { fg = c.blue, style = options.styles.functions }, -- function name (also: methods for classes)
-
-    Statement = { fg = c.magenta }, -- (preferred) any statement
-    -- Conditional   = { }, --  if, then, else, endif, switch, etc.
-    -- Repeat        = { }, --   for, do, while, etc.
-    -- Label         = { }, --    case, default, etc.
-    Operator = { fg = c.blue5 }, -- "sizeof", "+", "*", etc.
-    Keyword = { fg = c.cyan, style = options.styles.keywords }, --  any other keyword
-    -- Exception     = { }, --  try, catch, throw
-
-    PreProc = { fg = c.cyan }, -- (preferred) generic Preprocessor
-    -- Include       = { }, --  preprocessor #include
-    -- Define        = { }, --   preprocessor #define
-    -- Macro         = { }, --    same as Define
-    -- PreCondit     = { }, --  preprocessor #if, #else, #endif, etc.
-
-    Type = { fg = c.blue1 }, -- (preferred) int, long, char, etc.
-    -- StorageClass  = { }, -- static, register, volatile, etc.
-    -- Structure     = { }, --  struct, union, enum, etc.
-    -- Typedef       = { }, --  A typedef
-
-    Special = { fg = c.blue1 }, -- (preferred) any special symbol
-    -- SpecialChar   = { }, --  special character in a constant
-    -- Tag           = { }, --    you can use CTRL-] on this
-    -- Delimiter     = { }, --  character that needs attention
-    -- SpecialComment= { }, -- special things inside a comment
-    -- Debug         = { }, --    debugging statements
-
-    Underlined = { underline = true }, -- (preferred) text that stands out, HTML links
-    Bold = { bold = true },
-    Italic = { italic = true },
-
-    -- ("Ignore", below, may be invisible...)
-    -- Ignore = { }, -- (preferred) left blank, hidden  |hl-Ignore|
-
-    Error = { fg = c.error }, -- (preferred) any erroneous construct
-    Todo = { bg = c.yellow, fg = c.bg }, -- (preferred) anything that needs extra attention; mostly the keywords TODO FIXME and XXX
-
-    qfLineNr = { fg = c.dark5 },
-    qfFileName = { fg = c.blue },
-
-    htmlH1 = { fg = c.magenta, bold = true },
-    htmlH2 = { fg = c.blue, bold = true },
-
-    -- mkdHeading = { fg = c.orange, bold = true },
-    -- mkdCode = { bg = c.terminal_black, fg = c.fg },
-    mkdCodeDelimiter = { bg = c.terminal_black, fg = c.fg },
-    mkdCodeStart = { fg = c.teal, bold = true },
-    mkdCodeEnd = { fg = c.teal, bold = true },
-    -- mkdLink = { fg = c.blue, underline = true },
-
-    markdownHeadingDelimiter = { fg = c.orange, bold = true },
-    markdownCode = { fg = c.teal },
-    markdownCodeBlock = { fg = c.teal },
-    markdownH1 = { fg = c.magenta, bold = true },
-    markdownH2 = { fg = c.blue, bold = true },
-    markdownLinkText = { fg = c.blue, underline = true },
-
-    ["@punctuation.special.markdown"] = { fg = c.orange, bold = true },
-    ["@text.literal.markdown_inline"] = { bg = c.terminal_black, fg = c.blue },
-
-    debugPC = { bg = c.bg_sidebar }, -- used for highlighting the current line in terminal-debug
-    debugBreakpoint = { bg = util.darken(c.info, 0.1), fg = c.info }, -- used for breakpoint colors in terminal-debug
-
-    -- These groups are for the native LSP client. Some other LSP clients may
-    -- use these groups, or use their own. Consult your LSP client's
-    -- documentation.
-    LspReferenceText = { bg = c.fg_gutter }, -- used for highlighting "text" references
-    LspReferenceRead = { bg = c.fg_gutter }, -- used for highlighting "read" references
-    LspReferenceWrite = { bg = c.fg_gutter }, -- used for highlighting "write" references
-
-    DiagnosticError = { fg = c.error }, -- Used as the base highlight group. Other Diagnostic highlights link to this by default
-    DiagnosticWarn = { fg = c.warning }, -- Used as the base highlight group. Other Diagnostic highlights link to this by default
-    DiagnosticInfo = { fg = c.info }, -- Used as the base highlight group. Other Diagnostic highlights link to this by default
-    DiagnosticHint = { fg = c.hint }, -- Used as the base highlight group. Other Diagnostic highlights link to this by default
-
-    DiagnosticVirtualTextError = { bg = util.darken(c.error, 0.1), fg = c.error }, -- Used for "Error" diagnostic virtual text
-    DiagnosticVirtualTextWarn = { bg = util.darken(c.warning, 0.1), fg = c.warning }, -- Used for "Warning" diagnostic virtual text
-    DiagnosticVirtualTextInfo = { bg = util.darken(c.info, 0.1), fg = c.info }, -- Used for "Information" diagnostic virtual text
-    DiagnosticVirtualTextHint = { bg = util.darken(c.hint, 0.1), fg = c.hint }, -- Used for "Hint" diagnostic virtual text
-
-    DiagnosticUnderlineError = { undercurl = true, sp = c.error }, -- Used to underline "Error" diagnostics
-    DiagnosticUnderlineWarn = { undercurl = true, sp = c.warning }, -- Used to underline "Warning" diagnostics
-    DiagnosticUnderlineInfo = { undercurl = true, sp = c.info }, -- Used to underline "Information" diagnostics
-    DiagnosticUnderlineHint = { undercurl = true, sp = c.hint }, -- Used to underline "Hint" diagnostics
-
-    LspSignatureActiveParameter = { fg = c.orange },
-    LspCodeLens = { fg = c.comment },
-
-    LspInfoBorder = { fg = c.border_highlight, bg = c.bg_float },
-
-    ALEErrorSign = { fg = c.error },
-    ALEWarningSign = { fg = c.warning },
-
-    -- These groups are for the neovim tree-sitter highlights.
-    -- As of writing, tree-sitter support is a WIP, group names may change.
-    -- By default, most of these groups link to an appropriate Vim group,
-    -- TSError -> Error for example, so you do not have to define these unless
-    -- you explicitly want to support Treesitter's improved syntax awareness.
-
-    -- TSAnnotation        = { };    -- For C++/Dart attributes, annotations that can be attached to the code to denote some kind of meta information.
-    -- TSAttribute         = { };    -- (unstable) TODO: docs
-    -- TSBoolean           = { };    -- For booleans.
-    -- TSCharacter         = { };    -- For characters.
-    -- TSComment           = { };    -- For comment blocks.
-    TSNote = { fg = c.bg, bg = c.info },
-    TSWarning = { fg = c.bg, bg = c.warning },
-    TSDanger = { fg = c.bg, bg = c.error },
-    TSConstructor = { fg = c.magenta }, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
-    -- TSConditional       = { };    -- For keywords related to conditionnals.
-    -- TSConstant          = { };    -- For constants
-    -- TSConstBuiltin      = { };    -- For constant that are built in the language: `nil` in Lua.
-    -- TSConstMacro        = { };    -- For constants that are defined by macros: `NULL` in C.
-    -- TSError             = { };    -- For syntax/parser errors.
-    -- TSException         = { };    -- For exception related keywords.
-    TSField = { fg = c.green1 }, -- For fields.
-    -- TSFloat             = { };    -- For floats.
-    -- TSFunction          = { };    -- For function (calls and definitions).
-    -- TSFuncBuiltin       = { };    -- For builtin functions: `table.insert` in Lua.
-    -- TSFuncMacro         = { };    -- For macro defined fuctions (calls and definitions): each `macro_rules` in Rust.
-    -- TSInclude           = { };    -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
-    TSKeyword = { fg = c.purple, style = options.styles.keywords }, -- For keywords that don't fall in previous categories.
-    TSKeywordFunction = { fg = c.magenta, style = options.styles.functions }, -- For keywords used to define a fuction.
-    TSLabel = { fg = c.blue }, -- For labels: `label:` in C and `:label:` in Lua.
-    -- TSMethod            = { };    -- For method calls and definitions.
-    -- TSNamespace         = { };    -- For identifiers referring to modules and namespaces.
-    -- TSNone              = { };    -- TODO: docs
-    -- TSNumber            = { };    -- For all numbers
-    TSOperator = { fg = c.blue5 }, -- For any operator: `+`, but also `->` and `*` in C.
-    TSParameter = { fg = c.yellow }, -- For parameters of a function.
-    -- TSParameterReference= { };    -- For references to parameters of a function.
-    TSProperty = { fg = c.green1 }, -- Same as `TSField`.
-    TSPunctDelimiter = { fg = c.blue5 }, -- For delimiters ie: `.`
-    TSPunctBracket = { fg = c.fg_dark }, -- For brackets and parens.
-    TSPunctSpecial = { fg = c.blue5 }, -- For special punctutation that does not fall in the catagories before.
-    -- TSRepeat            = { };    -- For keywords related to loops.
-    -- TSString            = { };    -- For strings.
-    TSStringRegex = { fg = c.blue6 }, -- For regexes.
-    TSStringEscape = { fg = c.magenta }, -- For escape characters within a string.
-    -- TSSymbol            = { };    -- For identifiers referring to symbols or atoms.
-    -- TSType              = { };    -- For types.
-    -- TSTypeBuiltin       = { };    -- For builtin types.
-    TSVariable = { style = options.styles.variables }, -- Any variable name that does not have another highlight.
-    TSVariableBuiltin = { fg = c.red }, -- Variable names that are defined by the languages, like `this` or `self`.
-
-    -- TSTag               = { };    -- Tags like html tag names.
-    -- TSTagDelimiter      = { };    -- Tag delimiter like `<` `>` `/`
-    -- TSText              = { };    -- For strings considered text in a markup language.
-    TSTextReference = { fg = c.teal },
-    -- TSEmphasis          = { };    -- For text to be represented with emphasis.
-    -- TSUnderline         = { };    -- For text to be represented with an underline.
-    -- TSStrike            = { };    -- For strikethrough text.
-    -- TSTitle             = { };    -- Text that is part of a title.
-    -- TSLiteral           = { };    -- Literal text.
-    -- TSURI               = { };    -- Any URI like a link or email.
-
-    -- Lua
-    -- luaTSProperty = { fg = c.red }, -- Same as `TSField`.
-
-    -- ts-rainbow
-    rainbowcol1 = { fg = c.red },
-    rainbowcol2 = { fg = c.yellow },
-    rainbowcol3 = { fg = c.green },
-    rainbowcol4 = { fg = c.teal },
-    rainbowcol5 = { fg = c.blue },
-    rainbowcol6 = { fg = c.magenta },
-    rainbowcol7 = { fg = c.purple },
-
-    -- LspTrouble
-    TroubleText = { fg = c.fg_dark },
-    TroubleCount = { fg = c.magenta, bg = c.fg_gutter },
-    TroubleNormal = { fg = c.fg_sidebar, bg = c.bg_sidebar },
-
-    -- Illuminate
-    illuminatedWord = { bg = c.fg_gutter },
-    illuminatedCurWord = { bg = c.fg_gutter },
-    IlluminatedWordText = { bg = c.fg_gutter },
-    IlluminatedWordRead = { bg = c.fg_gutter },
-    IlluminatedWordWrite = { bg = c.fg_gutter },
-
-    -- diff
-    diffAdded = { fg = c.git.add },
-    diffRemoved = { fg = c.git.delete },
-    diffChanged = { fg = c.git.change },
-    diffOldFile = { fg = c.yellow },
-    diffNewFile = { fg = c.orange },
-    diffFile = { fg = c.blue },
-    diffLine = { fg = c.comment },
-    diffIndexLine = { fg = c.magenta },
-
-    -- Neogit
-    NeogitBranch = { fg = c.magenta },
-    NeogitRemote = { fg = c.purple },
-    NeogitHunkHeader = { bg = c.bg_highlight, fg = c.fg },
-    NeogitHunkHeaderHighlight = { bg = c.fg_gutter, fg = c.blue },
-    NeogitDiffContextHighlight = { bg = util.darken(c.fg_gutter, 0.5), fg = c.fg_dark },
-    NeogitDiffDeleteHighlight = { fg = c.git.delete, bg = c.diff.delete },
-    NeogitDiffAddHighlight = { fg = c.git.add, bg = c.diff.add },
-
-    -- Neotest
-    NeotestPassed = { fg = c.green },
-    NeotestRunning = { fg = c.yellow },
-    NeotestFailed = { fg = c.red },
-    NeotestSkipped = { fg = c.blue },
-    NeotestTest = { fg = c.fg_sidebar },
-    NeotestNamespace = { fg = c.green2 },
-    NeotestFocused = { fg = c.yellow },
-    NeotestFile = { fg = c.teal },
-    NeotestDir = { fg = c.blue },
-    NeotestBorder = { fg = c.blue },
-    NeotestIndent = { fg = c.fg_sidebar },
-    NeotestExpandMarker = { fg = c.fg_sidebar },
-    NeotestAdapterName = { fg = c.purple, bold = true },
-    NeotestWinSelect = { fg = c.blue },
-    NeotestMarked = { fg = c.blue },
-    NeotestTarget = { fg = c.blue },
-    --[[ NeotestUnknown = {}, ]]
-
-    -- GitGutter
-    GitGutterAdd = { fg = c.gitSigns.add }, -- diff mode: Added line |diff.txt|
-    GitGutterChange = { fg = c.gitSigns.change }, -- diff mode: Changed line |diff.txt|
-    GitGutterDelete = { fg = c.gitSigns.delete }, -- diff mode: Deleted line |diff.txt|
-
-    -- GitSigns
-    GitSignsAdd = { fg = c.gitSigns.add }, -- diff mode: Added line |diff.txt|
-    GitSignsChange = { fg = c.gitSigns.change }, -- diff mode: Changed line |diff.txt|
-    GitSignsDelete = { fg = c.gitSigns.delete }, -- diff mode: Deleted line |diff.txt|
-
-    -- Telescope
-    TelescopeBorder = { fg = c.border_highlight, bg = c.bg_float },
-    TelescopeNormal = { fg = c.fg, bg = c.bg_float },
-
-    -- NvimTree
-    NvimTreeNormal = { fg = c.fg_sidebar, bg = c.bg_sidebar },
-    NvimTreeWinSeparator = {
-      fg = options.styles.sidebars == "transparent" and c.border or c.bg_sidebar,
-      bg = c.bg_sidebar,
-    },
-    NvimTreeNormalNC = { fg = c.fg_sidebar, bg = c.bg_sidebar },
-    NvimTreeRootFolder = { fg = c.blue, bold = true },
-    NvimTreeGitDirty = { fg = c.git.change },
-    NvimTreeGitNew = { fg = c.git.add },
-    NvimTreeGitDeleted = { fg = c.git.delete },
-    NvimTreeOpenedFile = { bg = c.bg_highlight },
-    NvimTreeSpecialFile = { fg = c.purple, underline = true },
-    NvimTreeIndentMarker = { fg = c.fg_gutter },
-    NvimTreeImageFile = { fg = c.fg_sidebar },
-    NvimTreeSymlink = { fg = c.blue },
-    NvimTreeFolderIcon = { bg = c.none, fg = c.yellow },
-    -- NvimTreeFolderName= { fg = c.fg_float },
-
-    NeoTreeNormal = { fg = c.fg_sidebar, bg = c.bg_sidebar },
-    NeoTreeNormalNC = { fg = c.fg_sidebar, bg = c.bg_sidebar },
-
-    -- Fern
-    FernBranchText = { fg = c.blue },
-
-    -- glyph palette
-    GlyphPalette1 = { fg = c.red1 },
-    GlyphPalette2 = { fg = c.green },
-    GlyphPalette3 = { fg = c.yellow },
-    GlyphPalette4 = { fg = c.blue },
-    GlyphPalette6 = { fg = c.green1 },
-    GlyphPalette7 = { fg = c.fg },
-    GlyphPalette9 = { fg = c.red },
-
-    -- Dashboard
-    DashboardShortCut = { fg = c.cyan },
-    DashboardHeader = { fg = c.blue },
-    DashboardCenter = { fg = c.magenta },
-    DashboardFooter = { fg = c.yellow, italic = true },
-
-    -- Alpha
-    AlphaShortcut = { fg = c.cyan },
-    AlphaHeader = { fg = c.blue },
-    AlphaHeaderLabel = { fg = c.orange },
-    AlphaFooter = { fg = c.yellow, italic = true },
-    AlphaButtons = { fg = c.magenta },
-
-    -- WhichKey
-    WhichKey = { fg = c.cyan },
-    WhichKeyGroup = { fg = c.blue },
-    WhichKeyDesc = { fg = c.magenta },
-    WhichKeySeperator = { fg = c.comment },
-    WhichKeySeparator = { fg = c.comment },
-    WhichKeyFloat = { bg = c.bg_sidebar },
-    WhichKeyValue = { fg = c.dark5 },
-
-    -- LspSaga
-    DiagnosticWarning = { link = "DiagnosticWarn" },
-    DiagnosticInformation = { link = "DiagnosticInfo" },
-
-    LspFloatWinNormal = { bg = c.bg_float },
-    LspFloatWinBorder = { fg = c.border_highlight },
-    LspSagaBorderTitle = { fg = c.cyan },
-    LspSagaHoverBorder = { fg = c.blue },
-    LspSagaRenameBorder = { fg = c.green },
-    LspSagaDefPreviewBorder = { fg = c.green },
-    LspSagaCodeActionBorder = { fg = c.blue },
-    LspSagaFinderSelection = { fg = c.bg_visual },
-    LspSagaCodeActionTitle = { fg = c.blue1 },
-    LspSagaCodeActionContent = { fg = c.purple },
-    LspSagaSignatureHelpBorder = { fg = c.red },
-    ReferencesCount = { fg = c.purple },
-    DefinitionCount = { fg = c.purple },
-    DefinitionIcon = { fg = c.blue },
-    ReferencesIcon = { fg = c.blue },
-    TargetWord = { fg = c.cyan },
-
-    -- NeoVim
-    healthError = { fg = c.error },
-    healthSuccess = { fg = c.green1 },
-    healthWarning = { fg = c.warning },
-
-    -- BufferLine
-    BufferLineIndicatorSelected = { fg = c.git.change },
-
-    -- Barbar
-    BufferCurrent = { bg = c.fg_gutter, fg = c.fg },
-    BufferCurrentIndex = { bg = c.fg_gutter, fg = c.info },
-    BufferCurrentMod = { bg = c.fg_gutter, fg = c.warning },
-    BufferCurrentSign = { bg = c.fg_gutter, fg = c.info },
-    BufferCurrentTarget = { bg = c.fg_gutter, fg = c.red },
-    BufferVisible = { bg = c.bg_statusline, fg = c.fg },
-    BufferVisibleIndex = { bg = c.bg_statusline, fg = c.info },
-    BufferVisibleMod = { bg = c.bg_statusline, fg = c.warning },
-    BufferVisibleSign = { bg = c.bg_statusline, fg = c.info },
-    BufferVisibleTarget = { bg = c.bg_statusline, fg = c.red },
-    BufferInactive = { bg = c.bg_statusline, fg = c.dark5 },
-    BufferInactiveIndex = { bg = c.bg_statusline, fg = c.dark5 },
-    BufferInactiveMod = { bg = c.bg_statusline, fg = util.darken(c.warning, 0.7) },
-    BufferInactiveSign = { bg = c.bg_statusline, fg = c.border_highlight },
-    BufferInactiveTarget = { bg = c.bg_statusline, fg = c.red },
-    BufferTabpages = { bg = c.bg_statusline, fg = c.none },
-    BufferTabpage = { bg = c.bg_statusline, fg = c.border_highlight },
-
-    -- Sneak
-    Sneak = { fg = c.bg_highlight, bg = c.magenta },
-    SneakScope = { bg = c.bg_visual },
-
-    -- Hop
-    HopNextKey = { fg = c.magenta2, bold = true },
-    HopNextKey1 = { fg = c.blue2, bold = true },
-    HopNextKey2 = { fg = util.darken(c.blue2, 0.6) },
-    HopUnmatched = { fg = c.dark3 },
-
-    TSNodeKey = { fg = c.magenta2, bold = true },
-    TSNodeUnmatched = { fg = c.dark3 },
-
-    LeapMatch = { bg = c.magenta2, fg = c.fg, bold = true },
-    LeapLabelPrimary = { fg = c.magenta2, bold = true },
-    LeapLabelSecondary = { fg = c.green1, bold = true },
-    LeapBackdrop = { fg = c.dark3 },
-
-    LightspeedGreyWash = { fg = c.dark3 },
-    -- LightspeedCursor = { link = "Cursor" },
-    LightspeedLabel = { fg = c.magenta2, bold = true, underline = true },
-    LightspeedLabelDistant = { fg = c.green1, bold = true, underline = true },
-    LightspeedLabelDistantOverlapped = { fg = c.green2, underline = true },
-    LightspeedLabelOverlapped = { fg = c.magenta2, underline = true },
-    LightspeedMaskedChar = { fg = c.orange },
-    LightspeedOneCharMatch = { bg = c.magenta2, fg = c.fg, bold = true },
-    LightspeedPendingOpArea = { bg = c.magenta2, fg = c.fg },
-    LightspeedShortcut = { bg = c.magenta2, fg = c.fg, bold = true, underline = true },
-    -- LightspeedShortcutOverlapped = { link = "LightspeedShortcut" },
-    -- LightspeedUniqueChar = { link = "LightspeedUnlabeledMatch" },
-    LightspeedUnlabeledMatch = { fg = c.blue2, bold = true },
-
-    -- Cmp
-    CmpDocumentation = { fg = c.fg, bg = c.bg_float },
-    CmpDocumentationBorder = { fg = c.border_highlight, bg = c.bg_float },
-
-    CmpItemAbbr = { fg = c.fg, bg = c.none },
-    CmpItemAbbrDeprecated = { fg = c.fg_gutter, bg = c.none, strikethrough = true },
-    CmpItemAbbrMatch = { fg = c.blue1, bg = c.none },
-    CmpItemAbbrMatchFuzzy = { fg = c.blue1, bg = c.none },
-
-    CmpItemKindDefault = { fg = c.fg_dark, bg = c.none },
-    CmpItemMenu = { fg = c.comment, bg = c.none },
-
-    CmpItemKindKeyword = { fg = c.cyan, bg = c.none },
-
-    CmpItemKindVariable = { fg = c.magenta, bg = c.none },
-    CmpItemKindConstant = { fg = c.magenta, bg = c.none },
-    CmpItemKindReference = { fg = c.magenta, bg = c.none },
-    CmpItemKindValue = { fg = c.magenta, bg = c.none },
-
-    CmpItemKindFunction = { fg = c.blue, bg = c.none },
-    CmpItemKindMethod = { fg = c.blue, bg = c.none },
-    CmpItemKindConstructor = { fg = c.blue, bg = c.none },
-
-    CmpItemKindClass = { fg = c.orange, bg = c.none },
-    CmpItemKindInterface = { fg = c.orange, bg = c.none },
-    CmpItemKindStruct = { fg = c.orange, bg = c.none },
-    CmpItemKindEvent = { fg = c.orange, bg = c.none },
-    CmpItemKindEnum = { fg = c.orange, bg = c.none },
-    CmpItemKindUnit = { fg = c.orange, bg = c.none },
-
-    CmpItemKindModule = { fg = c.yellow, bg = c.none },
-
-    CmpItemKindProperty = { fg = c.green1, bg = c.none },
-    CmpItemKindField = { fg = c.green1, bg = c.none },
-    CmpItemKindTypeParameter = { fg = c.green1, bg = c.none },
-    CmpItemKindEnumMember = { fg = c.green1, bg = c.none },
-    CmpItemKindOperator = { fg = c.green1, bg = c.none },
-    CmpItemKindSnippet = { fg = c.dark5, bg = c.none },
-
-    -- navic
-    NavicIconsFile = { fg = c.fg, bg = c.none },
-    NavicIconsModule = { fg = c.yellow, bg = c.none },
-    NavicIconsNamespace = { fg = c.fg, bg = c.none },
-    NavicIconsPackage = { fg = c.fg, bg = c.none },
-    NavicIconsClass = { fg = c.orange, bg = c.none },
-    NavicIconsMethod = { fg = c.blue, bg = c.none },
-    NavicIconsProperty = { fg = c.green1, bg = c.none },
-    NavicIconsField = { fg = c.green1, bg = c.none },
-    NavicIconsConstructor = { fg = c.orange, bg = c.none },
-    NavicIconsEnum = { fg = c.orange, bg = c.none },
-    NavicIconsInterface = { fg = c.orange, bg = c.none },
-    NavicIconsFunction = { fg = c.blue, bg = c.none },
-    NavicIconsVariable = { fg = c.magenta, bg = c.none },
-    NavicIconsConstant = { fg = c.magenta, bg = c.none },
-    NavicIconsString = { fg = c.green, bg = c.none },
-    NavicIconsNumber = { fg = c.orange, bg = c.none },
-    NavicIconsBoolean = { fg = c.orange, bg = c.none },
-    NavicIconsArray = { fg = c.orange, bg = c.none },
-    NavicIconsObject = { fg = c.orange, bg = c.none },
-    NavicIconsKey = { fg = c.purple, bg = c.none },
-    NavicIconsKeyword = { fg = c.purple, bg = c.none },
-    NavicIconsNull = { fg = c.orange, bg = c.none },
-    NavicIconsEnumMember = { fg = c.green1, bg = c.none },
-    NavicIconsStruct = { fg = c.orange, bg = c.none },
-    NavicIconsEvent = { fg = c.orange, bg = c.none },
-    NavicIconsOperator = { fg = c.fg, bg = c.none },
-    NavicIconsTypeParameter = { fg = c.green1, bg = c.none },
-    NavicText = { fg = c.fg, bg = c.none },
-    NavicSeparator = { fg = c.fg, bg = c.none },
-
-    IndentBlanklineChar = { fg = c.fg_gutter },
-    IndentBlanklineContextChar = { fg = c.purple },
-
-    -- Scrollbar
-    ScrollbarHandle = { fg = c.none, bg = c.bg_highlight },
-
-    ScrollbarSearchHandle = { fg = c.orange, bg = c.bg_highlight },
-    ScrollbarSearch = { fg = c.orange, bg = c.none },
-
-    ScrollbarErrorHandle = { fg = c.error, bg = c.bg_highlight },
-    ScrollbarError = { fg = c.error, bg = c.none },
-
-    ScrollbarWarnHandle = { fg = c.warning, bg = c.bg_highlight },
-    ScrollbarWarn = { fg = c.warning, bg = c.none },
-
-    ScrollbarInfoHandle = { fg = c.info, bg = c.bg_highlight },
-    ScrollbarInfo = { fg = c.info, bg = c.none },
-
-    ScrollbarHintHandle = { fg = c.hint, bg = c.bg_highlight },
-    ScrollbarHint = { fg = c.hint, bg = c.none },
-
-    ScrollbarMiscHandle = { fg = c.purple, bg = c.bg_highlight },
-    ScrollbarMisc = { fg = c.purple, bg = c.none },
-
-    -- Yanky
-    YankyPut = { link = "IncSearch" },
-    YankyYanked = { link = "IncSearch" },
-
-    -- Notify
-    --- Border
-    NotifyERRORBorder = { fg = util.darken(c.error, 0.3), bg = c.bg },
-    NotifyWARNBorder  = { fg = util.darken(c.warning, 0.3), bg = c.bg },
-    NotifyINFOBorder  = { fg = util.darken(c.info, 0.3), bg = c.bg },
-    NotifyDEBUGBorder = { fg = util.darken(c.comment, 0.3), bg = c.bg },
-    NotifyTRACEBorder = { fg = util.darken(c.purple, 0.3), bg = c.bg },
-    --- Icons
-    NotifyERRORIcon   = { fg = c.error },
-    NotifyWARNIcon    = { fg = c.warning },
-    NotifyINFOIcon    = { fg = c.info },
-    NotifyDEBUGIcon   = { fg = c.comment },
-    NotifyTRACEIcon   = { fg = c.purple },
-    --- Title
-    NotifyERRORTitle  = { fg = c.error },
-    NotifyWARNTitle   = { fg = c.warning },
-    NotifyINFOTitle   = { fg = c.info },
-    NotifyDEBUGTitle  = { fg = c.comment },
-    NotifyTRACETitle  = { fg = c.purple },
-    --- Body
-    NotifyERRORBody   = { fg = c.fg, bg = c.bg },
-    NotifyWARNBody    = { fg = c.fg, bg = c.bg },
-    NotifyINFOBody    = { fg = c.fg, bg = c.bg },
-    NotifyDEBUGBody   = { fg = c.fg, bg = c.bg },
-    NotifyTRACEBody   = { fg = c.fg, bg = c.bg },
-
-    -- Mini
-    MiniCompletionActiveParameter = { underline = true },
-
-    MiniCursorword = { bg = c.fg_gutter },
-    MiniCursorwordCurrent = { bg = c.fg_gutter },
-
-    MiniIndentscopeSymbol = { fg = c.blue1 },
-    MiniIndentscopePrefix = { nocombine = true }, -- Make it invisible
-
-    MiniJump = { bg = c.magenta2, fg = "#ffffff" },
-
-    MiniJump2dSpot = { fg = c.magenta2, bold = true, nocombine = true },
-
-    MiniStarterCurrent = { nocombine = true },
-    MiniStarterFooter = { fg = c.yellow, italic = true },
-    MiniStarterHeader = { fg = c.blue },
-    MiniStarterInactive = { fg = c.comment, style = options.styles.comments },
-    MiniStarterItem = { fg = c.fg, bg = options.transparent and c.none or c.bg },
-    MiniStarterItemBullet = { fg = c.border_highlight },
-    MiniStarterItemPrefix = { fg = c.warning },
-    MiniStarterSection = { fg = c.blue1 },
-    MiniStarterQuery = { fg = c.info },
-
-    MiniStatuslineDevinfo = { fg = c.fg_dark, bg = c.bg_highlight },
-    MiniStatuslineFileinfo = { fg = c.fg_dark, bg = c.bg_highlight },
-    MiniStatuslineFilename = { fg = c.fg_dark, bg = c.fg_gutter },
-    MiniStatuslineInactive = { fg = c.blue, bg = c.bg_statusline },
-    MiniStatuslineModeCommand = { fg = c.black, bg = c.yellow, bold = true },
-    MiniStatuslineModeInsert = { fg = c.black, bg = c.green, bold = true },
-    MiniStatuslineModeNormal = { fg = c.black, bg = c.blue, bold = true },
-    MiniStatuslineModeOther = { fg = c.black, bg = c.teal, bold = true },
-    MiniStatuslineModeReplace = { fg = c.black, bg = c.red, bold = true },
-    MiniStatuslineModeVisual = { fg = c.black, bg = c.magenta, bold = true },
-
-    MiniSurround = { bg = c.orange, fg = c.black },
-
-    MiniTablineCurrent = { fg = c.fg, bg = c.fg_gutter },
-    MiniTablineFill = { bg = c.black },
-    MiniTablineHidden = { fg = c.dark5, bg = c.bg_statusline },
-    MiniTablineModifiedCurrent = { fg = c.warning, bg = c.fg_gutter },
-    MiniTablineModifiedHidden = { bg = c.bg_statusline, fg = util.darken(c.warning, 0.7) },
-    MiniTablineModifiedVisible = { fg = c.warning, bg = c.bg_statusline },
-    MiniTablineTabpagesection = { bg = c.bg_statusline, fg = c.none },
-    MiniTablineVisible = { fg = c.fg, bg = c.bg_statusline },
-
-    MiniTestEmphasis = { bold = true },
-    MiniTestFail = { fg = c.red, bold = true },
-    MiniTestPass = { fg = c.green, bold = true },
-
-    MiniTrailspace = { bg = c.red },
-  }
-
-  if not vim.diagnostic then
-    local severity_map = {
-      Error = "Error",
-      Warn = "Warning",
-      Info = "Information",
-      Hint = "Hint",
+    local config = require("tokyonight.config")
+    local options = config.options
+    ---@class Theme
+    ---@field highlights Highlights
+    local theme = {
+        config = options,
+        colors = colors.setup(),
     }
-    local types = { "Default", "VirtualText", "Underline" }
-    for _, type in ipairs(types) do
-      for snew, sold in pairs(severity_map) do
-        theme.highlights["LspDiagnostics" .. type .. sold] = {
-          link = "Diagnostic" .. (type == "Default" and "" or type) .. snew,
+
+    local c = theme.colors
+
+    theme.highlights = {
+        Foo = { bg = c.magenta2, fg = c.magenta2 },
+
+        Comment = { fg = c.comment, style = options.styles.comments }, -- any comment
+        ColorColumn = { bg = c.black }, -- used for the columns set with 'colorcolumn'
+        Conceal = { fg = c.dark5 }, -- placeholder characters substituted for concealed text (see 'conceallevel')
+        Cursor = { fg = c.bg, bg = c.fg }, -- character under the cursor
+        lCursor = { fg = c.bg, bg = c.fg }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
+        CursorIM = { fg = c.bg, bg = c.fg }, -- like Cursor, but used when in IME mode |CursorIM|
+        CursorColumn = { bg = c.bg_highlight }, -- Screen-column at the cursor, when 'cursorcolumn' is set.
+        CursorLine = { bg = c.bg_highlight }, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
+        Directory = { fg = c.blue }, -- directory names (and other special names in listings)
+        DiffAdd = { bg = c.diff.add }, -- diff mode: Added line |diff.txt|
+        DiffChange = { bg = c.diff.change }, -- diff mode: Changed line |diff.txt|
+        DiffDelete = { bg = c.diff.delete }, -- diff mode: Deleted line |diff.txt|
+        DiffText = { bg = c.diff.text }, -- diff mode: Changed text within a changed line |diff.txt|
+        EndOfBuffer = { fg = c.bg }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
+        -- TermCursor  = { }, -- cursor in a focused terminal
+        -- TermCursorNC= { }, -- cursor in an unfocused terminal
+        ErrorMsg = { fg = c.error }, -- error messages on the command line
+        VertSplit = { fg = c.border }, -- the column separating vertically split windows
+        WinSeparator = { fg = c.border, bold = true }, -- the column separating vertically split windows
+        Folded = { fg = c.blue, bg = c.fg_gutter }, -- line used for closed folds
+        FoldColumn = { bg = options.transparent and c.none or c.bg, fg = c.comment }, -- 'foldcolumn'
+        SignColumn = { bg = options.transparent and c.none or c.bg, fg = c.fg_gutter }, -- column where |signs| are displayed
+        SignColumnSB = { bg = c.bg_sidebar, fg = c.fg_gutter }, -- column where |signs| are displayed
+        Substitute = { bg = c.red, fg = c.black }, -- |:substitute| replacement text highlighting
+        LineNr = { fg = c.fg_gutter }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
+        CursorLineNr = { fg = c.dark5 }, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
+        MatchParen = { fg = c.orange, bold = true }, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
+        ModeMsg = { fg = c.fg_dark, bold = true }, -- 'showmode' message (e.g., "-- INSERT -- ")
+        MsgArea = { fg = c.fg_dark }, -- Area for messages and cmdline
+        -- MsgSeparator= { }, -- Separator for scrolled messages, `msgsep` flag of 'display'
+        MoreMsg = { fg = c.blue }, -- |more-prompt|
+        NonText = { fg = c.dark3 }, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
+        Normal = { fg = c.fg, bg = options.transparent and c.none or c.bg }, -- normal text
+        NormalNC = { fg = c.fg, bg = options.transparent and c.none or options.dim_inactive and c.bg_dark or c.bg }, -- normal text in non-current windows
+        NormalSB = { fg = c.fg_sidebar, bg = c.bg_sidebar }, -- normal text in sidebar
+        NormalFloat = { fg = c.fg, bg = c.bg_float }, -- Normal text in floating windows.
+        FloatBorder = { fg = c.border_highlight, bg = c.bg_float },
+        Pmenu = { bg = c.bg_popup, fg = c.fg }, -- Popup menu: normal item.
+        PmenuSel = { bg = util.darken(c.fg_gutter, 0.8) }, -- Popup menu: selected item.
+        PmenuSbar = { bg = util.lighten(c.bg_popup, 0.95) }, -- Popup menu: scrollbar.
+        PmenuThumb = { bg = c.fg_gutter }, -- Popup menu: Thumb of the scrollbar.
+        Question = { fg = c.blue }, -- |hit-enter| prompt and yes/no questions
+        QuickFixLine = { bg = c.bg_visual, bold = true }, -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
+        Search = { bg = c.bg_search, fg = c.fg }, -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.
+        IncSearch = { bg = c.orange, fg = c.black }, -- 'incsearch' highlighting; also used for the text replaced with ":s///c"
+        SpecialKey = { fg = c.dark3 }, -- Unprintable characters: text displayed differently from what it really is.  But not 'listchars' whitespace. |hl-Whitespace|
+        SpellBad = { sp = c.error, undercurl = true }, -- Word that is not recognized by the spellchecker. |spell| Combined with the highlighting used otherwise.
+        SpellCap = { sp = c.warning, undercurl = true }, -- Word that should start with a capital. |spell| Combined with the highlighting used otherwise.
+        SpellLocal = { sp = c.info, undercurl = true }, -- Word that is recognized by the spellchecker as one that is used in another region. |spell| Combined with the highlighting used otherwise.
+        SpellRare = { sp = c.hint, undercurl = true }, -- Word that is recognized by the spellchecker as one that is hardly ever used.  |spell| Combined with the highlighting used otherwise.
+        StatusLine = { fg = c.fg_sidebar, bg = c.bg_statusline }, -- status line of current window
+        StatusLineNC = { fg = c.fg_gutter, bg = c.bg_statusline }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
+        TabLine = { bg = c.bg_statusline, fg = c.fg_gutter }, -- tab pages line, not active tab page label
+        TabLineFill = { bg = c.black }, -- tab pages line, where there are no labels
+        TabLineSel = { fg = c.black, bg = c.blue }, -- tab pages line, active tab page label
+        Title = { fg = c.blue, bold = true }, -- titles for output from ":set all", ":autocmd" etc.
+        Visual = { bg = c.bg_visual }, -- Visual mode selection
+        VisualNOS = { bg = c.bg_visual }, -- Visual mode selection when vim is "Not Owning the Selection".
+        WarningMsg = { fg = c.warning }, -- warning messages
+        Whitespace = { fg = c.fg_gutter }, -- "nbsp", "space", "tab" and "trail" in 'listchars'
+        WildMenu = { bg = c.bg_visual }, -- current match in 'wildmenu' completion
+
+        -- These groups are not listed as default vim groups,
+        -- but they are defacto standard group names for syntax highlighting.
+        -- commented out groups should chain up to their "preferred" group by
+        -- default,
+        -- Uncomment and edit if you want more specific syntax highlighting.
+
+        Constant = { fg = c.orange }, -- (preferred) any constant
+        String = { fg = c.green }, --   a string constant: "this is a string"
+        Character = { fg = c.green }, --  a character constant: 'c', '\n'
+        -- Number        = { }, --   a number constant: 234, 0xff
+        -- Boolean       = { }, --  a boolean constant: TRUE, false
+        -- Float         = { }, --    a floating point constant: 2.3e10
+
+        Identifier = { fg = c.magenta, style = options.styles.variables }, -- (preferred) any variable name
+        Function = { fg = c.blue, style = options.styles.functions }, -- function name (also: methods for classes)
+
+        Statement = { fg = c.magenta }, -- (preferred) any statement
+        -- Conditional   = { }, --  if, then, else, endif, switch, etc.
+        -- Repeat        = { }, --   for, do, while, etc.
+        -- Label         = { }, --    case, default, etc.
+        Operator = { fg = c.blue5 }, -- "sizeof", "+", "*", etc.
+        Keyword = { fg = c.cyan, style = options.styles.keywords }, --  any other keyword
+        -- Exception     = { }, --  try, catch, throw
+
+        PreProc = { fg = c.cyan }, -- (preferred) generic Preprocessor
+        -- Include       = { }, --  preprocessor #include
+        -- Define        = { }, --   preprocessor #define
+        -- Macro         = { }, --    same as Define
+        -- PreCondit     = { }, --  preprocessor #if, #else, #endif, etc.
+
+        Type = { fg = c.blue1 }, -- (preferred) int, long, char, etc.
+        -- StorageClass  = { }, -- static, register, volatile, etc.
+        -- Structure     = { }, --  struct, union, enum, etc.
+        -- Typedef       = { }, --  A typedef
+
+        Special = { fg = c.blue1 }, -- (preferred) any special symbol
+        -- SpecialChar   = { }, --  special character in a constant
+        -- Tag           = { }, --    you can use CTRL-] on this
+        -- Delimiter     = { }, --  character that needs attention
+        -- SpecialComment= { }, -- special things inside a comment
+        -- Debug         = { }, --    debugging statements
+
+        Underlined = { underline = true }, -- (preferred) text that stands out, HTML links
+        Bold = { bold = true },
+        Italic = { italic = true },
+
+        -- ("Ignore", below, may be invisible...)
+        -- Ignore = { }, -- (preferred) left blank, hidden  |hl-Ignore|
+
+        Error = { fg = c.error }, -- (preferred) any erroneous construct
+        Todo = { bg = c.yellow, fg = c.bg }, -- (preferred) anything that needs extra attention; mostly the keywords TODO FIXME and XXX
+
+        qfLineNr = { fg = c.dark5 },
+        qfFileName = { fg = c.blue },
+
+        htmlH1 = { fg = c.magenta, bold = true },
+        htmlH2 = { fg = c.blue, bold = true },
+
+        -- mkdHeading = { fg = c.orange, bold = true },
+        -- mkdCode = { bg = c.terminal_black, fg = c.fg },
+        mkdCodeDelimiter = { bg = c.terminal_black, fg = c.fg },
+        mkdCodeStart = { fg = c.teal, bold = true },
+        mkdCodeEnd = { fg = c.teal, bold = true },
+        -- mkdLink = { fg = c.blue, underline = true },
+
+        markdownHeadingDelimiter = { fg = c.orange, bold = true },
+        markdownCode = { fg = c.teal },
+        markdownCodeBlock = { fg = c.teal },
+        markdownH1 = { fg = c.magenta, bold = true },
+        markdownH2 = { fg = c.blue, bold = true },
+        markdownLinkText = { fg = c.blue, underline = true },
+
+        ["@punctuation.special.markdown"] = { fg = c.orange, bold = true },
+        ["@text.literal.markdown_inline"] = { bg = c.terminal_black, fg = c.blue },
+
+        debugPC = { bg = c.bg_sidebar }, -- used for highlighting the current line in terminal-debug
+        debugBreakpoint = { bg = util.darken(c.info, 0.1), fg = c.info }, -- used for breakpoint colors in terminal-debug
+
+        -- These groups are for the native LSP client. Some other LSP clients may
+        -- use these groups, or use their own. Consult your LSP client's
+        -- documentation.
+        LspReferenceText = { bg = c.fg_gutter }, -- used for highlighting "text" references
+        LspReferenceRead = { bg = c.fg_gutter }, -- used for highlighting "read" references
+        LspReferenceWrite = { bg = c.fg_gutter }, -- used for highlighting "write" references
+
+        DiagnosticError = { fg = c.error }, -- Used as the base highlight group. Other Diagnostic highlights link to this by default
+        DiagnosticWarn = { fg = c.warning }, -- Used as the base highlight group. Other Diagnostic highlights link to this by default
+        DiagnosticInfo = { fg = c.info }, -- Used as the base highlight group. Other Diagnostic highlights link to this by default
+        DiagnosticHint = { fg = c.hint }, -- Used as the base highlight group. Other Diagnostic highlights link to this by default
+
+        DiagnosticVirtualTextError = { bg = util.darken(c.error, 0.1), fg = c.error }, -- Used for "Error" diagnostic virtual text
+        DiagnosticVirtualTextWarn = { bg = util.darken(c.warning, 0.1), fg = c.warning }, -- Used for "Warning" diagnostic virtual text
+        DiagnosticVirtualTextInfo = { bg = util.darken(c.info, 0.1), fg = c.info }, -- Used for "Information" diagnostic virtual text
+        DiagnosticVirtualTextHint = { bg = util.darken(c.hint, 0.1), fg = c.hint }, -- Used for "Hint" diagnostic virtual text
+
+        DiagnosticUnderlineError = { undercurl = true, sp = c.error }, -- Used to underline "Error" diagnostics
+        DiagnosticUnderlineWarn = { undercurl = true, sp = c.warning }, -- Used to underline "Warning" diagnostics
+        DiagnosticUnderlineInfo = { undercurl = true, sp = c.info }, -- Used to underline "Information" diagnostics
+        DiagnosticUnderlineHint = { undercurl = true, sp = c.hint }, -- Used to underline "Hint" diagnostics
+
+        LspSignatureActiveParameter = { fg = c.orange },
+        LspCodeLens = { fg = c.comment },
+
+        LspInfoBorder = { fg = c.border_highlight, bg = c.bg_float },
+
+        ALEErrorSign = { fg = c.error },
+        ALEWarningSign = { fg = c.warning },
+
+        -- These groups are for the neovim tree-sitter highlights.
+        -- As of writing, tree-sitter support is a WIP, group names may change.
+        -- By default, most of these groups link to an appropriate Vim group,
+        -- TSError -> Error for example, so you do not have to define these unless
+        -- you explicitly want to support Treesitter's improved syntax awareness.
+
+        -- TSAnnotation        = { };    -- For C++/Dart attributes, annotations that can be attached to the code to denote some kind of meta information.
+        -- TSAttribute         = { };    -- (unstable) TODO: docs
+        -- TSBoolean           = { };    -- For booleans.
+        -- TSCharacter         = { };    -- For characters.
+        -- TSComment           = { };    -- For comment blocks.
+        TSNote = { fg = c.bg, bg = c.info },
+        TSWarning = { fg = c.bg, bg = c.warning },
+        TSDanger = { fg = c.bg, bg = c.error },
+        TSConstructor = { fg = c.magenta }, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
+        -- TSConditional       = { };    -- For keywords related to conditionnals.
+        -- TSConstant          = { };    -- For constants
+        -- TSConstBuiltin      = { };    -- For constant that are built in the language: `nil` in Lua.
+        -- TSConstMacro        = { };    -- For constants that are defined by macros: `NULL` in C.
+        -- TSError             = { };    -- For syntax/parser errors.
+        -- TSException         = { };    -- For exception related keywords.
+        TSField = { fg = c.green1 }, -- For fields.
+        -- TSFloat             = { };    -- For floats.
+        -- TSFunction          = { };    -- For function (calls and definitions).
+        -- TSFuncBuiltin       = { };    -- For builtin functions: `table.insert` in Lua.
+        -- TSFuncMacro         = { };    -- For macro defined fuctions (calls and definitions): each `macro_rules` in Rust.
+        -- TSInclude           = { };    -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
+        TSKeyword = { fg = c.purple, style = options.styles.keywords }, -- For keywords that don't fall in previous categories.
+        TSKeywordFunction = { fg = c.magenta, style = options.styles.functions }, -- For keywords used to define a fuction.
+        TSLabel = { fg = c.blue }, -- For labels: `label:` in C and `:label:` in Lua.
+        -- TSMethod            = { };    -- For method calls and definitions.
+        -- TSNamespace         = { };    -- For identifiers referring to modules and namespaces.
+        -- TSNone              = { };    -- TODO: docs
+        -- TSNumber            = { };    -- For all numbers
+        TSOperator = { fg = c.blue5 }, -- For any operator: `+`, but also `->` and `*` in C.
+        TSParameter = { fg = c.yellow }, -- For parameters of a function.
+        -- TSParameterReference= { };    -- For references to parameters of a function.
+        TSProperty = { fg = c.green1 }, -- Same as `TSField`.
+        TSPunctDelimiter = { fg = c.blue5 }, -- For delimiters ie: `.`
+        TSPunctBracket = { fg = c.fg_dark }, -- For brackets and parens.
+        TSPunctSpecial = { fg = c.blue5 }, -- For special punctutation that does not fall in the catagories before.
+        -- TSRepeat            = { };    -- For keywords related to loops.
+        -- TSString            = { };    -- For strings.
+        TSStringRegex = { fg = c.blue6 }, -- For regexes.
+        TSStringEscape = { fg = c.magenta }, -- For escape characters within a string.
+        -- TSSymbol            = { };    -- For identifiers referring to symbols or atoms.
+        -- TSType              = { };    -- For types.
+        -- TSTypeBuiltin       = { };    -- For builtin types.
+        TSVariable = { style = options.styles.variables }, -- Any variable name that does not have another highlight.
+        TSVariableBuiltin = { fg = c.red }, -- Variable names that are defined by the languages, like `this` or `self`.
+
+        -- TSTag               = { };    -- Tags like html tag names.
+        -- TSTagDelimiter      = { };    -- Tag delimiter like `<` `>` `/`
+        -- TSText              = { };    -- For strings considered text in a markup language.
+        TSTextReference = { fg = c.teal },
+        -- TSEmphasis          = { };    -- For text to be represented with emphasis.
+        -- TSUnderline         = { };    -- For text to be represented with an underline.
+        -- TSStrike            = { };    -- For strikethrough text.
+        -- TSTitle             = { };    -- Text that is part of a title.
+        -- TSLiteral           = { };    -- Literal text.
+        -- TSURI               = { };    -- Any URI like a link or email.
+
+        -- Lua
+        -- luaTSProperty = { fg = c.red }, -- Same as `TSField`.
+
+        -- ts-rainbow
+        rainbowcol1 = { fg = c.red },
+        rainbowcol2 = { fg = c.yellow },
+        rainbowcol3 = { fg = c.green },
+        rainbowcol4 = { fg = c.teal },
+        rainbowcol5 = { fg = c.blue },
+        rainbowcol6 = { fg = c.magenta },
+        rainbowcol7 = { fg = c.purple },
+
+        -- LspTrouble
+        TroubleText = { fg = c.fg_dark },
+        TroubleCount = { fg = c.magenta, bg = c.fg_gutter },
+        TroubleNormal = { fg = c.fg_sidebar, bg = c.bg_sidebar },
+
+        -- Illuminate
+        illuminatedWord = { bg = c.fg_gutter },
+        illuminatedCurWord = { bg = c.fg_gutter },
+        IlluminatedWordText = { bg = c.fg_gutter },
+        IlluminatedWordRead = { bg = c.fg_gutter },
+        IlluminatedWordWrite = { bg = c.fg_gutter },
+
+        -- diff
+        diffAdded = { fg = c.git.add },
+        diffRemoved = { fg = c.git.delete },
+        diffChanged = { fg = c.git.change },
+        diffOldFile = { fg = c.yellow },
+        diffNewFile = { fg = c.orange },
+        diffFile = { fg = c.blue },
+        diffLine = { fg = c.comment },
+        diffIndexLine = { fg = c.magenta },
+
+        -- Neogit
+        NeogitBranch = { fg = c.magenta },
+        NeogitRemote = { fg = c.purple },
+        NeogitHunkHeader = { bg = c.bg_highlight, fg = c.fg },
+        NeogitHunkHeaderHighlight = { bg = c.fg_gutter, fg = c.blue },
+        NeogitDiffContextHighlight = { bg = util.darken(c.fg_gutter, 0.5), fg = c.fg_dark },
+        NeogitDiffDeleteHighlight = { fg = c.git.delete, bg = c.diff.delete },
+        NeogitDiffAddHighlight = { fg = c.git.add, bg = c.diff.add },
+
+        -- Neotest
+        NeotestPassed = { fg = c.green },
+        NeotestRunning = { fg = c.yellow },
+        NeotestFailed = { fg = c.red },
+        NeotestSkipped = { fg = c.blue },
+        NeotestTest = { fg = c.fg_sidebar },
+        NeotestNamespace = { fg = c.green2 },
+        NeotestFocused = { fg = c.yellow },
+        NeotestFile = { fg = c.teal },
+        NeotestDir = { fg = c.blue },
+        NeotestBorder = { fg = c.blue },
+        NeotestIndent = { fg = c.fg_sidebar },
+        NeotestExpandMarker = { fg = c.fg_sidebar },
+        NeotestAdapterName = { fg = c.purple, bold = true },
+        NeotestWinSelect = { fg = c.blue },
+        NeotestMarked = { fg = c.blue },
+        NeotestTarget = { fg = c.blue },
+        --[[ NeotestUnknown = {}, ]]
+
+        -- GitGutter
+        GitGutterAdd = { fg = c.gitSigns.add }, -- diff mode: Added line |diff.txt|
+        GitGutterChange = { fg = c.gitSigns.change }, -- diff mode: Changed line |diff.txt|
+        GitGutterDelete = { fg = c.gitSigns.delete }, -- diff mode: Deleted line |diff.txt|
+
+        -- GitSigns
+        GitSignsAdd = { fg = c.gitSigns.add }, -- diff mode: Added line |diff.txt|
+        GitSignsChange = { fg = c.gitSigns.change }, -- diff mode: Changed line |diff.txt|
+        GitSignsDelete = { fg = c.gitSigns.delete }, -- diff mode: Deleted line |diff.txt|
+
+        -- Telescope
+        TelescopeBorder = { fg = c.border_highlight, bg = c.bg_float },
+        TelescopeNormal = { fg = c.fg, bg = c.bg_float },
+
+        -- NvimTree
+        NvimTreeNormal = { fg = c.fg_sidebar, bg = c.bg_sidebar },
+        NvimTreeWinSeparator = {
+            fg = options.styles.sidebars == "transparent" and c.border or c.bg_sidebar,
+            bg = c.bg_sidebar,
+        },
+        NvimTreeNormalNC = { fg = c.fg_sidebar, bg = c.bg_sidebar },
+        NvimTreeRootFolder = { fg = c.blue, bold = true },
+        NvimTreeGitDirty = { fg = c.git.change },
+        NvimTreeGitNew = { fg = c.git.add },
+        NvimTreeGitDeleted = { fg = c.git.delete },
+        NvimTreeOpenedFile = { bg = c.bg_highlight },
+        NvimTreeSpecialFile = { fg = c.purple, underline = true },
+        NvimTreeIndentMarker = { fg = c.fg_gutter },
+        NvimTreeImageFile = { fg = c.fg_sidebar },
+        NvimTreeSymlink = { fg = c.blue },
+        NvimTreeFolderIcon = { bg = c.none, fg = c.yellow },
+        -- NvimTreeFolderName= { fg = c.fg_float },
+
+        NeoTreeNormal = { fg = c.fg_sidebar, bg = c.bg_sidebar },
+        NeoTreeNormalNC = { fg = c.fg_sidebar, bg = c.bg_sidebar },
+
+        -- Fern
+        FernBranchText = { fg = c.blue },
+
+        -- glyph palette
+        GlyphPalette1 = { fg = c.red1 },
+        GlyphPalette2 = { fg = c.green },
+        GlyphPalette3 = { fg = c.yellow },
+        GlyphPalette4 = { fg = c.blue },
+        GlyphPalette6 = { fg = c.green1 },
+        GlyphPalette7 = { fg = c.fg },
+        GlyphPalette9 = { fg = c.red },
+
+        -- Dashboard
+        DashboardShortCut = { fg = c.cyan },
+        DashboardHeader = { fg = c.blue },
+        DashboardCenter = { fg = c.magenta },
+        DashboardFooter = { fg = c.yellow, italic = true },
+
+        -- Alpha
+        AlphaShortcut = { fg = c.cyan },
+        AlphaHeader = { fg = c.blue },
+        AlphaHeaderLabel = { fg = c.orange },
+        AlphaFooter = { fg = c.yellow, italic = true },
+        AlphaButtons = { fg = c.magenta },
+
+        -- WhichKey
+        WhichKey = { fg = c.cyan },
+        WhichKeyGroup = { fg = c.blue },
+        WhichKeyDesc = { fg = c.magenta },
+        WhichKeySeperator = { fg = c.comment },
+        WhichKeySeparator = { fg = c.comment },
+        WhichKeyFloat = { bg = c.bg_sidebar },
+        WhichKeyValue = { fg = c.dark5 },
+
+        -- LspSaga
+        DiagnosticWarning = { link = "DiagnosticWarn" },
+        DiagnosticInformation = { link = "DiagnosticInfo" },
+
+        LspFloatWinNormal = { bg = c.bg_float },
+        LspFloatWinBorder = { fg = c.border_highlight },
+        LspSagaBorderTitle = { fg = c.cyan },
+        LspSagaHoverBorder = { fg = c.blue },
+        LspSagaRenameBorder = { fg = c.green },
+        LspSagaDefPreviewBorder = { fg = c.green },
+        LspSagaCodeActionBorder = { fg = c.blue },
+        LspSagaFinderSelection = { fg = c.bg_visual },
+        LspSagaCodeActionTitle = { fg = c.blue1 },
+        LspSagaCodeActionContent = { fg = c.purple },
+        LspSagaSignatureHelpBorder = { fg = c.red },
+        ReferencesCount = { fg = c.purple },
+        DefinitionCount = { fg = c.purple },
+        DefinitionIcon = { fg = c.blue },
+        ReferencesIcon = { fg = c.blue },
+        TargetWord = { fg = c.cyan },
+
+        -- NeoVim
+        healthError = { fg = c.error },
+        healthSuccess = { fg = c.green1 },
+        healthWarning = { fg = c.warning },
+
+        -- BufferLine
+        BufferLineIndicatorSelected = { fg = c.git.change },
+
+        -- Barbar
+        BufferCurrent = { bg = c.fg_gutter, fg = c.fg },
+        BufferCurrentIndex = { bg = c.fg_gutter, fg = c.info },
+        BufferCurrentMod = { bg = c.fg_gutter, fg = c.warning },
+        BufferCurrentSign = { bg = c.fg_gutter, fg = c.info },
+        BufferCurrentTarget = { bg = c.fg_gutter, fg = c.red },
+        BufferVisible = { bg = c.bg_statusline, fg = c.fg },
+        BufferVisibleIndex = { bg = c.bg_statusline, fg = c.info },
+        BufferVisibleMod = { bg = c.bg_statusline, fg = c.warning },
+        BufferVisibleSign = { bg = c.bg_statusline, fg = c.info },
+        BufferVisibleTarget = { bg = c.bg_statusline, fg = c.red },
+        BufferInactive = { bg = c.bg_statusline, fg = c.dark5 },
+        BufferInactiveIndex = { bg = c.bg_statusline, fg = c.dark5 },
+        BufferInactiveMod = { bg = c.bg_statusline, fg = util.darken(c.warning, 0.7) },
+        BufferInactiveSign = { bg = c.bg_statusline, fg = c.border_highlight },
+        BufferInactiveTarget = { bg = c.bg_statusline, fg = c.red },
+        BufferTabpages = { bg = c.bg_statusline, fg = c.none },
+        BufferTabpage = { bg = c.bg_statusline, fg = c.border_highlight },
+
+        -- Sneak
+        Sneak = { fg = c.bg_highlight, bg = c.magenta },
+        SneakScope = { bg = c.bg_visual },
+
+        -- Hop
+        HopNextKey = { fg = c.magenta2, bold = true },
+        HopNextKey1 = { fg = c.blue2, bold = true },
+        HopNextKey2 = { fg = util.darken(c.blue2, 0.6) },
+        HopUnmatched = { fg = c.dark3 },
+
+        TSNodeKey = { fg = c.magenta2, bold = true },
+        TSNodeUnmatched = { fg = c.dark3 },
+
+        LeapMatch = { bg = c.magenta2, fg = c.fg, bold = true },
+        LeapLabelPrimary = { fg = c.magenta2, bold = true },
+        LeapLabelSecondary = { fg = c.green1, bold = true },
+        LeapBackdrop = { fg = c.dark3 },
+
+        LightspeedGreyWash = { fg = c.dark3 },
+        -- LightspeedCursor = { link = "Cursor" },
+        LightspeedLabel = { fg = c.magenta2, bold = true, underline = true },
+        LightspeedLabelDistant = { fg = c.green1, bold = true, underline = true },
+        LightspeedLabelDistantOverlapped = { fg = c.green2, underline = true },
+        LightspeedLabelOverlapped = { fg = c.magenta2, underline = true },
+        LightspeedMaskedChar = { fg = c.orange },
+        LightspeedOneCharMatch = { bg = c.magenta2, fg = c.fg, bold = true },
+        LightspeedPendingOpArea = { bg = c.magenta2, fg = c.fg },
+        LightspeedShortcut = { bg = c.magenta2, fg = c.fg, bold = true, underline = true },
+        -- LightspeedShortcutOverlapped = { link = "LightspeedShortcut" },
+        -- LightspeedUniqueChar = { link = "LightspeedUnlabeledMatch" },
+        LightspeedUnlabeledMatch = { fg = c.blue2, bold = true },
+
+        -- Cmp
+        CmpDocumentation = { fg = c.fg, bg = c.bg_float },
+        CmpDocumentationBorder = { fg = c.border_highlight, bg = c.bg_float },
+
+        CmpItemAbbr = { fg = c.fg, bg = c.none },
+        CmpItemAbbrDeprecated = { fg = c.fg_gutter, bg = c.none, strikethrough = true },
+        CmpItemAbbrMatch = { fg = c.blue1, bg = c.none },
+        CmpItemAbbrMatchFuzzy = { fg = c.blue1, bg = c.none },
+
+        CmpItemKindDefault = { fg = c.fg_dark, bg = c.none },
+        CmpItemMenu = { fg = c.comment, bg = c.none },
+
+        CmpItemKindKeyword = { fg = c.cyan, bg = c.none },
+
+        CmpItemKindVariable = { fg = c.magenta, bg = c.none },
+        CmpItemKindConstant = { fg = c.magenta, bg = c.none },
+        CmpItemKindReference = { fg = c.magenta, bg = c.none },
+        CmpItemKindValue = { fg = c.magenta, bg = c.none },
+
+        CmpItemKindFunction = { fg = c.blue, bg = c.none },
+        CmpItemKindMethod = { fg = c.blue, bg = c.none },
+        CmpItemKindConstructor = { fg = c.blue, bg = c.none },
+
+        CmpItemKindClass = { fg = c.orange, bg = c.none },
+        CmpItemKindInterface = { fg = c.orange, bg = c.none },
+        CmpItemKindStruct = { fg = c.orange, bg = c.none },
+        CmpItemKindEvent = { fg = c.orange, bg = c.none },
+        CmpItemKindEnum = { fg = c.orange, bg = c.none },
+        CmpItemKindUnit = { fg = c.orange, bg = c.none },
+
+        CmpItemKindModule = { fg = c.yellow, bg = c.none },
+
+        CmpItemKindProperty = { fg = c.green1, bg = c.none },
+        CmpItemKindField = { fg = c.green1, bg = c.none },
+        CmpItemKindTypeParameter = { fg = c.green1, bg = c.none },
+        CmpItemKindEnumMember = { fg = c.green1, bg = c.none },
+        CmpItemKindOperator = { fg = c.green1, bg = c.none },
+        CmpItemKindSnippet = { fg = c.dark5, bg = c.none },
+
+        -- navic
+        NavicIconsFile = { fg = c.fg, bg = c.none },
+        NavicIconsModule = { fg = c.yellow, bg = c.none },
+        NavicIconsNamespace = { fg = c.fg, bg = c.none },
+        NavicIconsPackage = { fg = c.fg, bg = c.none },
+        NavicIconsClass = { fg = c.orange, bg = c.none },
+        NavicIconsMethod = { fg = c.blue, bg = c.none },
+        NavicIconsProperty = { fg = c.green1, bg = c.none },
+        NavicIconsField = { fg = c.green1, bg = c.none },
+        NavicIconsConstructor = { fg = c.orange, bg = c.none },
+        NavicIconsEnum = { fg = c.orange, bg = c.none },
+        NavicIconsInterface = { fg = c.orange, bg = c.none },
+        NavicIconsFunction = { fg = c.blue, bg = c.none },
+        NavicIconsVariable = { fg = c.magenta, bg = c.none },
+        NavicIconsConstant = { fg = c.magenta, bg = c.none },
+        NavicIconsString = { fg = c.green, bg = c.none },
+        NavicIconsNumber = { fg = c.orange, bg = c.none },
+        NavicIconsBoolean = { fg = c.orange, bg = c.none },
+        NavicIconsArray = { fg = c.orange, bg = c.none },
+        NavicIconsObject = { fg = c.orange, bg = c.none },
+        NavicIconsKey = { fg = c.purple, bg = c.none },
+        NavicIconsKeyword = { fg = c.purple, bg = c.none },
+        NavicIconsNull = { fg = c.orange, bg = c.none },
+        NavicIconsEnumMember = { fg = c.green1, bg = c.none },
+        NavicIconsStruct = { fg = c.orange, bg = c.none },
+        NavicIconsEvent = { fg = c.orange, bg = c.none },
+        NavicIconsOperator = { fg = c.fg, bg = c.none },
+        NavicIconsTypeParameter = { fg = c.green1, bg = c.none },
+        NavicText = { fg = c.fg, bg = c.none },
+        NavicSeparator = { fg = c.fg, bg = c.none },
+
+        IndentBlanklineChar = { fg = c.fg_gutter },
+        IndentBlanklineContextChar = { fg = c.purple },
+
+        -- Scrollbar
+        ScrollbarHandle = { fg = c.none, bg = c.bg_highlight },
+
+        ScrollbarSearchHandle = { fg = c.orange, bg = c.bg_highlight },
+        ScrollbarSearch = { fg = c.orange, bg = c.none },
+
+        ScrollbarErrorHandle = { fg = c.error, bg = c.bg_highlight },
+        ScrollbarError = { fg = c.error, bg = c.none },
+
+        ScrollbarWarnHandle = { fg = c.warning, bg = c.bg_highlight },
+        ScrollbarWarn = { fg = c.warning, bg = c.none },
+
+        ScrollbarInfoHandle = { fg = c.info, bg = c.bg_highlight },
+        ScrollbarInfo = { fg = c.info, bg = c.none },
+
+        ScrollbarHintHandle = { fg = c.hint, bg = c.bg_highlight },
+        ScrollbarHint = { fg = c.hint, bg = c.none },
+
+        ScrollbarMiscHandle = { fg = c.purple, bg = c.bg_highlight },
+        ScrollbarMisc = { fg = c.purple, bg = c.none },
+
+        -- Yanky
+        YankyPut = { link = "IncSearch" },
+        YankyYanked = { link = "IncSearch" },
+
+        -- Notify
+        --- Border
+        NotifyERRORBorder = { fg = util.darken(c.error, 0.3), bg = options.transparent and c.none or c.bg },
+        NotifyWARNBorder = { fg = util.darken(c.warning, 0.3), bg = options.transparent and c.none or c.bg },
+        NotifyINFOBorder = { fg = util.darken(c.info, 0.3), bg = options.transparent and c.none or c.bg },
+        NotifyDEBUGBorder = { fg = util.darken(c.comment, 0.3), bg = options.transparent and c.none or c.bg },
+        NotifyTRACEBorder = { fg = util.darken(c.purple, 0.3), bg = options.transparent and c.none or c.bg },
+        --- Icons
+        NotifyERRORIcon = { fg = c.error },
+        NotifyWARNIcon = { fg = c.warning },
+        NotifyINFOIcon = { fg = c.info },
+        NotifyDEBUGIcon = { fg = c.comment },
+        NotifyTRACEIcon = { fg = c.purple },
+        --- Title
+        NotifyERRORTitle = { fg = c.error },
+        NotifyWARNTitle = { fg = c.warning },
+        NotifyINFOTitle = { fg = c.info },
+        NotifyDEBUGTitle = { fg = c.comment },
+        NotifyTRACETitle = { fg = c.purple },
+        --- Body
+        NotifyERRORBody = { fg = c.fg, bg = options.transparent and c.none or c.bg },
+        NotifyWARNBody = { fg = c.fg, bg = options.transparent and c.none or c.bg },
+        NotifyINFOBody = { fg = c.fg, bg = options.transparent and c.none or c.bg },
+        NotifyDEBUGBody = { fg = c.fg, bg = options.transparent and c.none or c.bg },
+        NotifyTRACEBody = { fg = c.fg, bg = options.transparent and c.none or c.bg },
+
+        -- Mini
+        MiniCompletionActiveParameter = { underline = true },
+
+        MiniCursorword = { bg = c.fg_gutter },
+        MiniCursorwordCurrent = { bg = c.fg_gutter },
+
+        MiniIndentscopeSymbol = { fg = c.blue1 },
+        MiniIndentscopePrefix = { nocombine = true }, -- Make it invisible
+
+        MiniJump = { bg = c.magenta2, fg = "#ffffff" },
+
+        MiniJump2dSpot = { fg = c.magenta2, bold = true, nocombine = true },
+
+        MiniStarterCurrent = { nocombine = true },
+        MiniStarterFooter = { fg = c.yellow, italic = true },
+        MiniStarterHeader = { fg = c.blue },
+        MiniStarterInactive = { fg = c.comment, style = options.styles.comments },
+        MiniStarterItem = { fg = c.fg, bg = options.transparent and c.none or c.bg },
+        MiniStarterItemBullet = { fg = c.border_highlight },
+        MiniStarterItemPrefix = { fg = c.warning },
+        MiniStarterSection = { fg = c.blue1 },
+        MiniStarterQuery = { fg = c.info },
+
+        MiniStatuslineDevinfo = { fg = c.fg_dark, bg = c.bg_highlight },
+        MiniStatuslineFileinfo = { fg = c.fg_dark, bg = c.bg_highlight },
+        MiniStatuslineFilename = { fg = c.fg_dark, bg = c.fg_gutter },
+        MiniStatuslineInactive = { fg = c.blue, bg = c.bg_statusline },
+        MiniStatuslineModeCommand = { fg = c.black, bg = c.yellow, bold = true },
+        MiniStatuslineModeInsert = { fg = c.black, bg = c.green, bold = true },
+        MiniStatuslineModeNormal = { fg = c.black, bg = c.blue, bold = true },
+        MiniStatuslineModeOther = { fg = c.black, bg = c.teal, bold = true },
+        MiniStatuslineModeReplace = { fg = c.black, bg = c.red, bold = true },
+        MiniStatuslineModeVisual = { fg = c.black, bg = c.magenta, bold = true },
+
+        MiniSurround = { bg = c.orange, fg = c.black },
+
+        MiniTablineCurrent = { fg = c.fg, bg = c.fg_gutter },
+        MiniTablineFill = { bg = c.black },
+        MiniTablineHidden = { fg = c.dark5, bg = c.bg_statusline },
+        MiniTablineModifiedCurrent = { fg = c.warning, bg = c.fg_gutter },
+        MiniTablineModifiedHidden = { bg = c.bg_statusline, fg = util.darken(c.warning, 0.7) },
+        MiniTablineModifiedVisible = { fg = c.warning, bg = c.bg_statusline },
+        MiniTablineTabpagesection = { bg = c.bg_statusline, fg = c.none },
+        MiniTablineVisible = { fg = c.fg, bg = c.bg_statusline },
+
+        MiniTestEmphasis = { bold = true },
+        MiniTestFail = { fg = c.red, bold = true },
+        MiniTestPass = { fg = c.green, bold = true },
+
+        MiniTrailspace = { bg = c.red },
+    }
+
+    if not vim.diagnostic then
+        local severity_map = {
+            Error = "Error",
+            Warn = "Warning",
+            Info = "Information",
+            Hint = "Hint",
         }
-      end
-    end
-  end
-
-  theme.defer = {}
-
-  if options.hide_inactive_statusline then
-    local inactive = { underline = true, bg = c.none, fg = c.bg, sp = c.border }
-
-    -- StatusLineNC
-    theme.highlights.StatusLineNC = inactive
-
-    -- LuaLine
-    for _, section in ipairs({ "a", "b", "c" }) do
-      theme.defer["lualine_" .. section .. "_inactive"] = inactive
+        local types = { "Default", "VirtualText", "Underline" }
+        for _, type in ipairs(types) do
+            for snew, sold in pairs(severity_map) do
+                theme.highlights["LspDiagnostics" .. type .. sold] = {
+                    link = "Diagnostic" .. (type == "Default" and "" or type) .. snew,
+                }
+            end
+        end
     end
 
-    -- mini.statusline
-    theme.highlights.MiniStatuslineInactive = inactive
-  end
+    theme.defer = {}
 
-  options.on_highlights(theme.highlights, theme.colors)
+    if options.hide_inactive_statusline then
+        local inactive = { underline = true, bg = c.none, fg = c.bg, sp = c.border }
 
-  if config.is_day() then
-    util.invert_colors(theme.colors)
-    util.invert_highlights(theme.highlights)
-  end
+        -- StatusLineNC
+        theme.highlights.StatusLineNC = inactive
 
-  return theme
+        -- LuaLine
+        for _, section in ipairs({ "a", "b", "c" }) do
+            theme.defer["lualine_" .. section .. "_inactive"] = inactive
+        end
+
+        -- mini.statusline
+        theme.highlights.MiniStatuslineInactive = inactive
+    end
+
+    options.on_highlights(theme.highlights, theme.colors)
+
+    if config.is_day() then
+        util.invert_colors(theme.colors)
+        util.invert_highlights(theme.highlights)
+    end
+
+    return theme
 end
 
 return M


### PR DESCRIPTION
When using [nvim-notify](https://github.com/rcarriga/nvim-notify), if `transparent = true` is valid, I want the background to be transparent as well. 

### before
![修正前](https://user-images.githubusercontent.com/80927666/194913384-2ed51826-43df-4b92-9d9c-cc37f374bfb8.png)
### After
![修正後](https://user-images.githubusercontent.com/80927666/194913508-5df54733-f1e8-454a-88ce-e6c921095a04.png)
