### PR TITLE
fix: Make background transparent when nvim-notify is used

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -571,11 +571,11 @@ function M.setup()
 
     -- Notify
     --- Border
-    NotifyERRORBorder = { fg = util.darken(c.error, 0.3), bg = c.bg },
-    NotifyWARNBorder  = { fg = util.darken(c.warning, 0.3), bg = c.bg },
-    NotifyINFOBorder  = { fg = util.darken(c.info, 0.3), bg = c.bg },
-    NotifyDEBUGBorder = { fg = util.darken(c.comment, 0.3), bg = c.bg },
-    NotifyTRACEBorder = { fg = util.darken(c.purple, 0.3), bg = c.bg },
+    NotifyERRORBorder = { fg = util.darken(c.error, 0.3), bg = options.transparent and c.none or c.bg },
+    NotifyWARNBorder  = { fg = util.darken(c.warning, 0.3), bg = options.transparent and c.none or c.bg },
+    NotifyINFOBorder  = { fg = util.darken(c.info, 0.3), bg = options.transparent and c.none or c.bg },
+    NotifyDEBUGBorder = { fg = util.darken(c.comment, 0.3), bg = options.transparent and c.none or c.bg },
+    NotifyTRACEBorder = { fg = util.darken(c.purple, 0.3), bg = options.transparent and c.none or c.bg },
     --- Icons
     NotifyERRORIcon   = { fg = c.error },
     NotifyWARNIcon    = { fg = c.warning },
@@ -589,11 +589,11 @@ function M.setup()
     NotifyDEBUGTitle  = { fg = c.comment },
     NotifyTRACETitle  = { fg = c.purple },
     --- Body
-    NotifyERRORBody   = { fg = c.fg, bg = c.bg },
-    NotifyWARNBody    = { fg = c.fg, bg = c.bg },
-    NotifyINFOBody    = { fg = c.fg, bg = c.bg },
-    NotifyDEBUGBody   = { fg = c.fg, bg = c.bg },
-    NotifyTRACEBody   = { fg = c.fg, bg = c.bg },
+    NotifyERRORBody   = { fg = c.fg, bg = options.transparent and c.none or c.bg },
+    NotifyWARNBody    = { fg = c.fg, bg = options.transparent and c.none or c.bg },
+    NotifyINFOBody    = { fg = c.fg, bg = options.transparent and c.none or c.bg },
+    NotifyDEBUGBody   = { fg = c.fg, bg = options.transparent and c.none or c.bg },
+    NotifyTRACEBody   = { fg = c.fg, bg = options.transparent and c.none or c.bg },
 
     -- Mini
     MiniCompletionActiveParameter = { underline = true },


### PR DESCRIPTION
git diff was strange, I pull request it again,(sorry)

When using [nvim-notify](https://github.com/rcarriga/nvim-notify), if `transparent = true` is valid, I want the background to be transparent as well. 

### before
![修正前](https://user-images.githubusercontent.com/80927666/194913384-2ed51826-43df-4b92-9d9c-cc37f374bfb8.png)
### After
![修正後](https://user-images.githubusercontent.com/80927666/194913508-5df54733-f1e8-454a-88ce-e6c921095a04.png)