### PR TITLE
fix(kitty): Add window border colors

### DIFF
--- a/extras/kitty/tokyonight_day.conf
+++ b/extras/kitty/tokyonight_day.conf
@@ -21,6 +21,10 @@ inactive_tab_background #c4c8da
 inactive_tab_foreground #8990b3
 #tab_bar_background #e9e9ed
 
+# Windows
+active_border_color #2e7de9
+inactive_border_color #c4c8da
+
 # normal
 color0 #e9e9ed
 color1 #f52a65
@@ -44,4 +48,3 @@ color15 #3760bf
 # extended colors
 color16 #b15c00
 color17 #c64343
-  

--- a/extras/kitty/tokyonight_moon.conf
+++ b/extras/kitty/tokyonight_moon.conf
@@ -21,6 +21,10 @@ inactive_tab_background #2f334d
 inactive_tab_foreground #545c7e
 #tab_bar_background #1b1d2b
 
+# Windows
+active_border_color #82aaff
+inactive_border_color #2f334d
+
 # normal
 color0 #1b1d2b
 color1 #ff757f
@@ -44,4 +48,3 @@ color15 #c8d3f5
 # extended colors
 color16 #ff966c
 color17 #c53b53
-  

--- a/extras/kitty/tokyonight_night.conf
+++ b/extras/kitty/tokyonight_night.conf
@@ -21,6 +21,10 @@ inactive_tab_background #292e42
 inactive_tab_foreground #545c7e
 #tab_bar_background #15161e
 
+# Windows
+active_border_color #7aa2f7
+inactive_border_color #292e42
+
 # normal
 color0 #15161e
 color1 #f7768e
@@ -44,4 +48,3 @@ color15 #c0caf5
 # extended colors
 color16 #ff9e64
 color17 #db4b4b
-  

--- a/extras/kitty/tokyonight_storm.conf
+++ b/extras/kitty/tokyonight_storm.conf
@@ -21,6 +21,10 @@ inactive_tab_background #292e42
 inactive_tab_foreground #545c7e
 #tab_bar_background #1d202f
 
+# Windows
+active_border_color #7aa2f7
+inactive_border_color #2f334d
+
 # normal
 color0 #1d202f
 color1 #f7768e
@@ -44,4 +48,3 @@ color15 #c0caf5
 # extended colors
 color16 #ff9e64
 color17 #db4b4b
-  

--- a/lua/tokyonight/extra/kitty.lua
+++ b/lua/tokyonight/extra/kitty.lua
@@ -29,6 +29,10 @@ inactive_tab_background ${bg_highlight}
 inactive_tab_foreground ${dark3}
 #tab_bar_background ${black}
 
+# Windows
+active_border_color ${blue}
+inactive_border_color ${bg_highlight}
+
 # normal
 color0 ${black}
 color1 ${red}


### PR DESCRIPTION
Add some color to the window borders of the kitty terminal.
The default kitty colors look pretty jarring IMHO.
I'm not sure what the best colors are. I reused some of the existing colors from tabs and checked that there is enough difference between the active and inactive states.