### PR TITLE
Replace tokyonight-day with `background=light`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ require("tokyonight").setup({
   -- your configuration comes here
   -- or leave it empty to use the default settings
   style = "storm", -- The theme comes in three styles, `storm`, `moon`, a darker variant `night` and `day`
-  light_style = "day", -- The theme is used when the background is set to light
   transparent = false, -- Enable this to disable setting the background color
   terminal_colors = true, -- Configure the colors used when opening a `:terminal` in Neovim
   styles = {

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ extra themes for Kitty, Alacritty, iTerm and Fish.
 
 ## Day
 
+```
+colorscheme tokyonight-storm
+set vim.o.background=light
+```
+
+
 ![image](https://user-images.githubusercontent.com/292349/115996270-78c6c480-a593-11eb-8ed0-7d1400b058f5.png)
 
 ## ✨ Features

--- a/colors/tokyonight-day.lua
+++ b/colors/tokyonight-day.lua
@@ -1,1 +1,0 @@
-require("tokyonight")._load("day")

--- a/doc/tokyonight.txt
+++ b/doc/tokyonight.txt
@@ -168,7 +168,7 @@ TokyoNight will use the default options, unless you call `setup`.
     require("tokyonight").setup({
       -- your configuration comes here
       -- or leave it empty to use the default settings
-      style = "storm", -- The theme comes in three styles, `storm`, `moon`, a darker variant `night` and `moon`
+      style = "storm", -- The theme comes in three styles, `storm`, `moon`, and a darker variant `night`.
       transparent = false, -- Enable this to disable setting the background color
       terminal_colors = true, -- Configure the colors used when opening a `:terminal` in Neovim
       styles = {

--- a/doc/tokyonight.txt
+++ b/doc/tokyonight.txt
@@ -7,7 +7,6 @@ Table of Contents                               *tokyonight-table-of-contents*
   - Storm                                                   |tokyonight-storm|
   - Night                                                   |tokyonight-night|
   - Moon                                                     |tokyonight-moon|
-  - Day                                                       |tokyonight-day|
   - ✨ Features                                     |tokyonight-✨-features|
   - ⚡️ Requirements                       |tokyonight-⚡️-requirements|
   - 📦 Installation                           |tokyonight-📦-installation|
@@ -42,13 +41,6 @@ MOON                                                         *tokyonight-moon*
 
 <div class="figure">
 <img src="https://user-images.githubusercontent.com/292349/190951628-10ba28a1-57ff-4479-8eab-47400a402242.png" title="fig:"/>
-<p class="caption">image</p>
-</div>
-
-DAY                                                           *tokyonight-day*
-
-<div class="figure">
-<img src="https://user-images.githubusercontent.com/292349/115996270-78c6c480-a593-11eb-8ed0-7d1400b058f5.png" title="fig:"/>
 <p class="caption">image</p>
 </div>
 
@@ -126,7 +118,6 @@ Enable the colorscheme:
     " There are also colorschemes for the different styles
     colorscheme tokyonight-night
     colorscheme tokyonight-storm
-    colorscheme tokyonight-day
     colorscheme tokyonight-moon
 <
 
@@ -166,14 +157,9 @@ To enable the `tokyonight` colorscheme for `Lightline`:
   `colorscheme tokyonight`
 
 
-The theme comes in four styles, `storm`, `moon`, a darker variant `night` and
-`day`.
+The theme comes in four styles, `storm`, `moon`, and a darker variant, `night`.
 
-The **day** style will be used if:
-
-
-- `{ style = "day"}` was passed to `setup(options)`
-- or `vim.o.background = "light"`
+A light variant will be used if `vim.o.background = "light"`.
 
 
 TokyoNight will use the default options, unless you call `setup`.
@@ -182,8 +168,7 @@ TokyoNight will use the default options, unless you call `setup`.
     require("tokyonight").setup({
       -- your configuration comes here
       -- or leave it empty to use the default settings
-      style = "storm", -- The theme comes in three styles, `storm`, `moon`, a darker variant `night` and `day`
-      light_style = "day", -- The theme is used when the background is set to light
+      style = "storm", -- The theme comes in three styles, `storm`, `moon`, a darker variant `night` and `moon`
       transparent = false, -- Enable this to disable setting the background color
       terminal_colors = true, -- Configure the colors used when opening a `:terminal` in Neovim
       styles = {
@@ -229,8 +214,8 @@ How the highlight groups are calculated:
 
 
 Please refer to default values for `colors` and `highlights` for the storm
-<extras/lua_tokyonight_storm.lua>, moon <extras/lua_tokyonight_moon.lua>, night
-<extras/lua_tokyonight_night.lua>, day <extras/lua_tokyonight_day.lua>
+<extras/lua_tokyonight_storm.lua>, moon <extras/lua_tokyonight_moon.lua> and night
+<extras/lua_tokyonight_night.lua>.
 
 Example for changing some settings and colors
 

--- a/lua/tokyonight/colors.lua
+++ b/lua/tokyonight/colors.lua
@@ -46,7 +46,6 @@ M.night = {
   bg = "#1a1b26",
   bg_dark = "#16161e",
 }
-M.day = M.night
 
 M.moon = function()
   local ret = {
@@ -99,7 +98,7 @@ function M.setup(opts)
   opts = opts or {}
   local config = require("tokyonight.config")
 
-  local style = config.is_day() and config.options.light_style or config.options.style
+  local style = config.options.style
   local palette = M[style] or {}
   if type(palette) == "function" then
     palette = palette()
@@ -147,7 +146,7 @@ function M.setup(opts)
   colors.hint = colors.teal
 
   config.options.on_colors(colors)
-  if opts.transform and config.is_day() then
+  if opts.transform and vim.o.background == "light" then
     util.invert_colors(colors)
   end
 

--- a/lua/tokyonight/config.lua
+++ b/lua/tokyonight/config.lua
@@ -4,8 +4,7 @@ local M = {}
 ---@field on_colors fun(colors: ColorScheme)
 ---@field on_highlights fun(highlights: Highlights, colors: ColorScheme)
 local defaults = {
-  style = "storm", -- The theme comes in three styles, `storm`, a darker variant `night` and `day`
-  light_style = "day", -- The theme is used when the background is set to light
+  style = "storm", -- The theme comes in three styles, `storm`, a darker variant `night` and `moon`
   transparent = false, -- Enable this to disable setting the background color
   terminal_colors = true, -- Configure the colors used when opening a `:terminal` in Neovim
   styles = {
@@ -35,7 +34,6 @@ local defaults = {
   ---@param highlights Highlights
   ---@param colors ColorScheme
   on_highlights = function(highlights, colors) end,
-  use_background = true, -- can be light/dark/auto. When auto, background will be set to vim.o.background
 }
 
 ---@type Config
@@ -49,10 +47,6 @@ end
 ---@param options Config|nil
 function M.extend(options)
   M.options = vim.tbl_deep_extend("force", {}, M.options or defaults, options or {})
-end
-
-function M.is_day()
-  return M.options.style == "day" or M.options.use_background and vim.o.background == "light"
 end
 
 M.setup()

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -30,7 +30,6 @@ function M.setup()
   local styles = {
     storm = " Storm",
     night = "",
-    day = " Day",
     moon = " Moon",
   }
 

--- a/lua/tokyonight/init.lua
+++ b/lua/tokyonight/init.lua
@@ -12,7 +12,7 @@ function M._load(style)
     require("tokyonight.config").options.style = M._style
     M._style = nil
   end
-  M.load({ style = style, use_background = style == nil })
+  M.load({ style = style })
 end
 
 ---@param opts Config|nil

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -684,7 +684,7 @@ function M.setup()
 
   options.on_highlights(theme.highlights, theme.colors)
 
-  if config.is_day() then
+  if vim.o.background == "light" then
     util.invert_colors(theme.colors)
     util.invert_highlights(theme.highlights)
   end


### PR DESCRIPTION
Drop `tokyonight-day`. Use `vim.o.background=light` instead.

Using `vim.o.background` also allows these pairs:

    colorscheme tokyonight-night
    set vim.o.background=light

    # This is equivalent to tokyonight-day
    colorscheme tokyonight-storm
    set vim.o.background=light

    colorscheme tokyonight-moon
    set vim.o.background=light

---

My intent here is to simplify light mode a bit. Currently there's two distinct way to use a light mode; with `vim.o.background` (which gives three variants) or using the day theme (which allows using only the storm-light variant).

My goal with these changes is to eventually make it possible to define overrides that only apply when `vim.o.background = "light"`. The way the day (a.k.a.: "storm+light") variant is special cased, makes this pretty tricky.

All-in-all, I feel this reduces completely while increases flexibility; there will only be _one_ way of specifying that one wants a light variant, but the light variant for all three are usable.