### PR TITLE
fix: `bg_float` when `styles.floats` is normal

### DIFF
--- a/lua/tokyonight/colors.lua
+++ b/lua/tokyonight/colors.lua
@@ -135,7 +135,7 @@ function M.setup(opts)
 
   colors.bg_float = config.options.styles.floats == "transparent" and colors.none
     or config.options.styles.floats == "dark" and colors.bg_dark
-    or "none"
+    or "NONE"
 
   colors.bg_visual = util.darken(colors.blue0, 0.7)
   colors.bg_search = colors.blue0


### PR DESCRIPTION
When `styles.floats` is `normal` and `background=light`, the `none` can not be ignored by the `util.invert_colors`, and which will break `hsluv.hex_to_hsluv`:


https://github.com/folke/tokyonight.nvim/blob/29e2c689c10679f723ae1deadf7f0067d394a545/lua/tokyonight/util.lua#L39-L43