### PR TITLE
feat: Add themes for terminator terminal

### DIFF
--- a/extras/terminator/tokyonight_day.conf
+++ b/extras/terminator/tokyonight_day.conf
@@ -1,0 +1,5 @@
+[[Tokyo Night Day]]
+  palette = "#e9e9ed:#f52a65:#587539:#8c6c3e:#2e7de9:#9854f1:#007197:#6172b0:#a1a6c5:#f52a65:#587539:#8c6c3e:#2e7de9:#9854f1:#007197:#7847bd"
+  background_color = "#e1e2e7"
+  foreground_color = "#3760bf"
+  

--- a/extras/terminator/tokyonight_moon.conf
+++ b/extras/terminator/tokyonight_moon.conf
@@ -1,0 +1,5 @@
+[[Tokyo Night Moon]]
+  palette = "#1b1d2b:#ff757f:#c3e88d:#ffc777:#82aaff:#c099ff:#86e1fc:#828bb8:#444a73:#ff757f:#c3e88d:#ffc777:#82aaff:#c099ff:#86e1fc:#fca7ea"
+  background_color = "#222436"
+  foreground_color = "#c8d3f5"
+  

--- a/extras/terminator/tokyonight_night.conf
+++ b/extras/terminator/tokyonight_night.conf
@@ -1,0 +1,5 @@
+[[Tokyo Night]]
+  palette = "#15161e:#f7768e:#9ece6a:#e0af68:#7aa2f7:#bb9af7:#7dcfff:#a9b1d6:#414868:#f7768e:#9ece6a:#e0af68:#7aa2f7:#bb9af7:#7dcfff:#9d7cd8"
+  background_color = "#1a1b26"
+  foreground_color = "#c0caf5"
+  

--- a/extras/terminator/tokyonight_storm.conf
+++ b/extras/terminator/tokyonight_storm.conf
@@ -1,0 +1,5 @@
+[[Tokyo Night Storm]]
+  palette = "#1d202f:#f7768e:#9ece6a:#e0af68:#7aa2f7:#bb9af7:#7dcfff:#a9b1d6:#414868:#f7768e:#9ece6a:#e0af68:#7aa2f7:#bb9af7:#7dcfff:#9d7cd8"
+  background_color = "#24283b"
+  foreground_color = "#c0caf5"
+  

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -27,6 +27,7 @@ function M.setup()
     lua = "lua",
     sublime = "tmTheme",
     delta = "gitconfig",
+    terminator = "conf",
   }
   -- map of style to style name
   local styles = {

--- a/lua/tokyonight/extra/terminator.lua
+++ b/lua/tokyonight/extra/terminator.lua
@@ -1,0 +1,19 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @param colors ColorScheme
+function M.generate(colors)
+  local terminator = util.template(
+    [=[
+[[${_style_name}]]
+  palette = "${black}:${red}:${green}:${yellow}:${blue}:${magenta}:${cyan}:${fg_dark}:${terminal_black}:${red}:${green}:${yellow}:${blue}:${magenta}:${cyan}:${purple}"
+  background_color = "${bg}"
+  foreground_color = "${fg}"
+  ]=],
+    colors
+  )
+  return terminator
+end
+
+return M


### PR DESCRIPTION
Thanks for the great theme and neovim plugins. 

This PR adds theme config files for the [terminator](https://github.com/gnome-terminator/terminator) terminal. 