### PR TITLE
feat: add signify support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ extra themes for Kitty, Alacritty, iTerm and Fish.
 - [LSP Saga](https://github.com/glepnir/lspsaga.nvim)
 - [Git Signs](https://github.com/lewis6991/gitsigns.nvim)
 - [Git Gutter](https://github.com/airblade/vim-gitgutter)
+- [Signify](https://github.com/mhinz/vim-signify)
 - [Telescope](https://github.com/nvim-telescope/telescope.nvim)
 - [NvimTree](https://github.com/kyazdani42/nvim-tree.lua)
 - [WhichKey](https://github.com/liuchengxu/vim-which-key)

--- a/doc/tokyonight.txt
+++ b/doc/tokyonight.txt
@@ -75,6 +75,7 @@ PLUGIN SUPPORT ~
 - LSP Saga <https://github.com/glepnir/lspsaga.nvim>
 - Git Signs <https://github.com/lewis6991/gitsigns.nvim>
 - Git Gutter <https://github.com/airblade/vim-gitgutter>
+- Signify <https://github.com/mhinz/vim-signify>
 - Telescope <https://github.com/nvim-telescope/telescope.nvim>
 - NvimTree <https://github.com/kyazdani42/nvim-tree.lua>
 - WhichKey <https://github.com/liuchengxu/vim-which-key>

--- a/extras/lua/tokyonight_day.lua
+++ b/extras/lua/tokyonight_day.lua
@@ -499,6 +499,15 @@ local highlights = {
     fg = "#2e7de9",
     style = {}
   },
+  SignifySignAdd = {
+    fg = "#399a96"
+  },
+  SignifySignChange = {
+    fg = "#6382bd"
+  },
+  SignifySignDelete = {
+    fg = "#c25d64"
+  },
   GitGutterAdd = {
     fg = "#399a96"
   },

--- a/extras/lua/tokyonight_moon.lua
+++ b/extras/lua/tokyonight_moon.lua
@@ -499,6 +499,15 @@ local highlights = {
     fg = "#82aaff",
     style = {}
   },
+  SignifySignAdd = {
+    fg = "#627259"
+  },
+  SignifySignChange = {
+    fg = "#485a86"
+  },
+  SignifySignDelete = {
+    fg = "#b55a67"
+  },
   GitGutterAdd = {
     fg = "#627259"
   },

--- a/extras/lua/tokyonight_night.lua
+++ b/extras/lua/tokyonight_night.lua
@@ -499,6 +499,15 @@ local highlights = {
     fg = "#7aa2f7",
     style = {}
   },
+  SignifySignAdd = {
+    fg = "#399a96"
+  },
+  SignifySignChange = {
+    fg = "#6382bd"
+  },
+  SignifySignDelete = {
+    fg = "#c25d64"
+  },
   GitGutterAdd = {
     fg = "#399a96"
   },

--- a/extras/lua/tokyonight_storm.lua
+++ b/extras/lua/tokyonight_storm.lua
@@ -499,6 +499,15 @@ local highlights = {
     fg = "#7aa2f7",
     style = {}
   },
+  SignifySignAdd = {
+    fg = "#399a96"
+  },
+  SignifySignChange = {
+    fg = "#6382bd"
+  },
+  SignifySignDelete = {
+    fg = "#c25d64"
+  },
   GitGutterAdd = {
     fg = "#399a96"
   },

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -327,6 +327,11 @@ function M.setup()
     NeotestTarget = { fg = c.blue },
     --[[ NeotestUnknown = {}, ]]
 
+    -- Signify
+    SignifySignAdd = { fg = c.gitSigns.add }, -- diff mode: Added line |diff.txt|
+    SignifySignChange = { fg = c.gitSigns.change }, -- diff mode: Changed line |diff.txt|
+    SignifySignDelete = { fg = c.gitSigns.delete }, -- diff mode: Deleted line |diff.txt|
+
     -- GitGutter
     GitGutterAdd = { fg = c.gitSigns.add }, -- diff mode: Added line |diff.txt|
     GitGutterChange = { fg = c.gitSigns.change }, -- diff mode: Changed line |diff.txt|


### PR DESCRIPTION
Both [Git Gutter](https://github.com/airblade/vim-gitgutter) and [Git Signs](https://github.com/lewis6991/gitsigns.nvim) are supported. This pull request adds support for [Signify](https://github.com/mhinz/vim-signify).

Without Signify support a workaround like the following is required.

```
function! TokyonightThemeHighlighting()
  highlight SignifySignAdd    guifg=#399a96
  highlight SignifySignChange guifg=#6382bd
  highlight SignifySignDelete guifg=#c25d64
endfunction

augroup TokyonightThemeAutoCommands
  autocmd!
  au ColorScheme tokyonight,tokyonight-storm,tokyonight-night,tokyonight-moon
               \ call TokyonightThemeHighlighting()
augroup END
```