### PR TITLE
add installation example using lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ Plug 'folke/tokyonight.nvim', { 'branch': 'main' }
 use 'folke/tokyonight.nvim'
 ```
 
+[lazy.nvim](https://github.com/folke/lazy.nvim)
+
+```lua
+{
+  "folke/tokyonight.nvim",
+  lazy = false,
+  priority = 1000,
+  opts = { style = "moon" },
+  config = function(_, opts)
+    local tokyonight = require("tokyonight")
+    tokyonight.setup(opts)
+    tokyonight.load()
+  end,
+}
+```
+
 ## 🚀 Usage
 
 Enable the colorscheme:


### PR DESCRIPTION
Adds an installation/configuration example using `lazy.nvim`. 😃

 if you find this too verbose feel free to disregard; I can understand the desire to have this documented only in `lazy.nvim` for maintenance purposes.

Also, since other package managers have an `Installation` and `Configuration` section separately, then this may not make sense in this format.

