### PR TITLE
feat: add Vimwiki color support

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -717,6 +717,20 @@ function M.setup()
     TreesitterContext = { bg = util.darken(c.fg_gutter, 0.8) },
     Hlargs = { fg = c.yellow },
     -- TreesitterContext = { bg = util.darken(c.bg_visual, 0.4) },
+
+    -- VimWiki
+    VimwikiLink = { fg = c.blue, bg = c.none },
+    VimwikiHeaderChar = { fg = c.yellow, bg = c.none },
+    VimwikiHR = { fg = c.yellow, bg = c.none },
+    VimwikiList = { fg = c.orange, bg = c.none },
+    VimwikiTag = { fg = c.green, bg = c.none },
+    VimwikiMarkers = { fg = c.blue, bg = c.none },
+    VimwikiHeader1 = { fg = c.orange, bg = c.none, bold = true },
+    VimwikiHeader2 = { fg = c.red, bg = c.none, bold = true },
+    VimwikiHeader3 = { fg = c.blue, bg = c.none, bold = true },
+    VimwikiHeader4 = { fg = c.cyan, bg = c.none, bold = true },
+    VimwikiHeader5 = { fg = c.yellow, bg = c.none, bold = true },
+    VimwikiHeader6 = { fg = c.purple, bg = c.none, bold = true },
   }
 
   if not vim.diagnostic then

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -725,12 +725,11 @@ function M.setup()
     VimwikiList = { fg = c.orange, bg = c.none },
     VimwikiTag = { fg = c.green, bg = c.none },
     VimwikiMarkers = { fg = c.blue, bg = c.none },
-    VimwikiHeader1 = { fg = c.orange, bg = c.none, bold = true },
-    VimwikiHeader2 = { fg = c.red, bg = c.none, bold = true },
-    VimwikiHeader3 = { fg = c.blue, bg = c.none, bold = true },
-    VimwikiHeader4 = { fg = c.cyan, bg = c.none, bold = true },
-    VimwikiHeader5 = { fg = c.yellow, bg = c.none, bold = true },
-    VimwikiHeader6 = { fg = c.purple, bg = c.none, bold = true },
+    VimwikiHeader1 = { fg = c.red, bg = c.none, bold = true },
+    VimwikiHeader2 = { fg = c.yellow, bg = c.none, bold = true },
+    VimwikiHeader3 = { fg = c.green, bg = c.none, bold = true },
+    VimwikiHeader4 = { fg = c.teal, bg = c.none, bold = true },
+    VimwikiHeader5 = { fg = c.blue, bg = c.none, bold = true },
   }
 
   if not vim.diagnostic then


### PR DESCRIPTION
Add Vimwiki support. I tried to follow rainbow bracket color order as best as I could.

It looks like:

<img width="133" alt="Screenshot 2023-01-09 at 11 03 35 PM" src="https://user-images.githubusercontent.com/431893/211459346-cf3830a7-03c7-4b54-9fb3-e57f75dd89dc.png">
