### PR TITLE
Don't hardcode background and foreground colours in Sublime theme

### DIFF
--- a/extras/sublime/tokyonight_day.tmTheme
+++ b/extras/sublime/tokyonight_day.tmTheme
@@ -17,7 +17,7 @@
 				<key>activeGuide</key>
 				<string>#363b54</string>
 				<key>background</key>
-				<string>#1d1f29</string>
+				<string>#e1e2e7</string>
 				<key>caret</key>
 				<string>#DBC08A</string>
 				<key>findHighlight</key>
@@ -25,7 +25,7 @@
 				<key>findHighlightForeground</key>
 				<string>#000000</string>
 				<key>foreground</key>
-				<string>#AFBAD4ff</string>
+				<string>#3760bf</string>
 				<key>guide</key>
 				<string>#4f4f5e40</string>
 				<key>gutterForeground</key>

--- a/extras/sublime/tokyonight_moon.tmTheme
+++ b/extras/sublime/tokyonight_moon.tmTheme
@@ -17,7 +17,7 @@
 				<key>activeGuide</key>
 				<string>#363b54</string>
 				<key>background</key>
-				<string>#1d1f29</string>
+				<string>#222436</string>
 				<key>caret</key>
 				<string>#DBC08A</string>
 				<key>findHighlight</key>
@@ -25,7 +25,7 @@
 				<key>findHighlightForeground</key>
 				<string>#000000</string>
 				<key>foreground</key>
-				<string>#AFBAD4ff</string>
+				<string>#c8d3f5</string>
 				<key>guide</key>
 				<string>#4f4f5e40</string>
 				<key>gutterForeground</key>

--- a/extras/sublime/tokyonight_night.tmTheme
+++ b/extras/sublime/tokyonight_night.tmTheme
@@ -17,7 +17,7 @@
 				<key>activeGuide</key>
 				<string>#363b54</string>
 				<key>background</key>
-				<string>#1d1f29</string>
+				<string>#1a1b26</string>
 				<key>caret</key>
 				<string>#DBC08A</string>
 				<key>findHighlight</key>
@@ -25,7 +25,7 @@
 				<key>findHighlightForeground</key>
 				<string>#000000</string>
 				<key>foreground</key>
-				<string>#AFBAD4ff</string>
+				<string>#c0caf5</string>
 				<key>guide</key>
 				<string>#4f4f5e40</string>
 				<key>gutterForeground</key>

--- a/extras/sublime/tokyonight_storm.tmTheme
+++ b/extras/sublime/tokyonight_storm.tmTheme
@@ -17,7 +17,7 @@
 				<key>activeGuide</key>
 				<string>#363b54</string>
 				<key>background</key>
-				<string>#1d1f29</string>
+				<string>#24283b</string>
 				<key>caret</key>
 				<string>#DBC08A</string>
 				<key>findHighlight</key>
@@ -25,7 +25,7 @@
 				<key>findHighlightForeground</key>
 				<string>#000000</string>
 				<key>foreground</key>
-				<string>#AFBAD4ff</string>
+				<string>#c0caf5</string>
 				<key>guide</key>
 				<string>#4f4f5e40</string>
 				<key>gutterForeground</key>

--- a/lua/tokyonight/extra/sublime.lua
+++ b/lua/tokyonight/extra/sublime.lua
@@ -55,7 +55,7 @@ M.template = [[
 				<key>activeGuide</key>
 				<string>#363b54</string>
 				<key>background</key>
-				<string>#1d1f29</string>
+				<string>${bg}</string>
 				<key>caret</key>
 				<string>#DBC08A</string>
 				<key>findHighlight</key>
@@ -63,7 +63,7 @@ M.template = [[
 				<key>findHighlightForeground</key>
 				<string>#000000</string>
 				<key>foreground</key>
-				<string>#AFBAD4ff</string>
+				<string>${fg}</string>
 				<key>guide</key>
 				<string>#4f4f5e40</string>
 				<key>gutterForeground</key>


### PR DESCRIPTION
Fixes #284

A number of other colours are also hardcoded, but as I don't use Sublime Text itself I can't say what the best choices for them are.
