### PR TITLE
Add style to g:colors_name

### DIFF
--- a/lua/tokyonight/util.lua
+++ b/lua/tokyonight/util.lua
@@ -177,7 +177,7 @@ function M.load(theme)
   end
 
   vim.o.termguicolors = true
-  vim.g.colors_name = "tokyonight"
+  vim.g.colors_name = "tokyonight" .. "-" .. theme.config.style
 
   if ts.new_style() then
     for group, colors in pairs(ts.defaults) do


### PR DESCRIPTION
Fixes #300.

This doesn't handle "default", where the style isn't set, so `g:colors_name` will never say just `tokyonight` which is annoying, but I don't know enough about lua to figure out a "default" value that acts like "storm" when needed.