### PR TITLE
fix: treesitter todo keyword highlight

### DIFF
--- a/lua/tokyonight/treesitter.lua
+++ b/lua/tokyonight/treesitter.lua
@@ -88,7 +88,7 @@ M.fallbacks = {
   ["text.note"] = "TSNote",
   ["text.warning"] = "TSWarning",
   ["text.danger"] = "TSDanger",
-  ["todo"] = "TSTodo",
+  ["text.todo"] = "TSTodo",
   ["type"] = "TSType",
   ["type.builtin"] = "TSTypeBuiltin",
   ["type.qualifier"] = "TSTypeQualifier",
@@ -351,7 +351,7 @@ M.defaults = {
     default = true,
     link = "Todo",
   },
-  ["@todo"] = {
+  ["@text.todo"] = {
     default = true,
     link = "Todo",
   },


### PR DESCRIPTION
this pr fix the `TODO` keyword highlight

![image](https://user-images.githubusercontent.com/2351076/217724486-419ad6e5-6ec2-4ec3-9a51-75394e5a8713.png)
