### PR TITLE
feat(windows_terminal): add Windows Terminal colors

### DIFF
--- a/extras/windows_terminal/tokyonight_day.json
+++ b/extras/windows_terminal/tokyonight_day.json
@@ -1,0 +1,25 @@
+# Add the following object to your Windows Terminal configuration
+# https://learn.microsoft.com/en-us/windows/terminal/customize-settings/color-schemes#creating-your-own-color-scheme
+{
+    "background": "#e1e2e7",
+    "black": "#e9e9ed",
+    "blue": "#2e7de9",
+    "brightBlack": "#a1a6c5",
+    "brightBlue": "#2e7de9",
+    "brightCyan": "#007197",
+    "brightGreen": "#587539",
+    "brightPurple": "#7847bd",
+    "brightRed": "#f52a65",
+    "brightWhite": "#3760bf",
+    "brightYellow": "#8c6c3e",
+    "cursorColor": "#3760bf",
+    "cyan": "#007197",
+    "foreground": "#3760bf",
+    "green": "#587539",
+    "name": "Tokyo Night Day",
+    "purple": "#9854f1",
+    "red": "#f52a65",
+    "selectionBackground": "#99a7df",
+    "white": "#6172b0",
+    "yellow": "#8c6c3e"
+}

--- a/extras/windows_terminal/tokyonight_moon.json
+++ b/extras/windows_terminal/tokyonight_moon.json
@@ -1,0 +1,25 @@
+# Add the following object to your Windows Terminal configuration
+# https://learn.microsoft.com/en-us/windows/terminal/customize-settings/color-schemes#creating-your-own-color-scheme
+{
+    "background": "#222436",
+    "black": "#1b1d2b",
+    "blue": "#82aaff",
+    "brightBlack": "#444a73",
+    "brightBlue": "#82aaff",
+    "brightCyan": "#86e1fc",
+    "brightGreen": "#c3e88d",
+    "brightPurple": "#fca7ea",
+    "brightRed": "#ff757f",
+    "brightWhite": "#c8d3f5",
+    "brightYellow": "#ffc777",
+    "cursorColor": "#c8d3f5",
+    "cyan": "#86e1fc",
+    "foreground": "#c8d3f5",
+    "green": "#c3e88d",
+    "name": "Tokyo Night Moon",
+    "purple": "#c099ff",
+    "red": "#ff757f",
+    "selectionBackground": "#3654a7",
+    "white": "#828bb8",
+    "yellow": "#ffc777"
+}

--- a/extras/windows_terminal/tokyonight_night.json
+++ b/extras/windows_terminal/tokyonight_night.json
@@ -1,0 +1,25 @@
+# Add the following object to your Windows Terminal configuration
+# https://learn.microsoft.com/en-us/windows/terminal/customize-settings/color-schemes#creating-your-own-color-scheme
+{
+    "background": "#1a1b26",
+    "black": "#15161e",
+    "blue": "#7aa2f7",
+    "brightBlack": "#414868",
+    "brightBlue": "#7aa2f7",
+    "brightCyan": "#7dcfff",
+    "brightGreen": "#9ece6a",
+    "brightPurple": "#9d7cd8",
+    "brightRed": "#f7768e",
+    "brightWhite": "#c0caf5",
+    "brightYellow": "#e0af68",
+    "cursorColor": "#c0caf5",
+    "cyan": "#7dcfff",
+    "foreground": "#c0caf5",
+    "green": "#9ece6a",
+    "name": "Tokyo Night",
+    "purple": "#bb9af7",
+    "red": "#f7768e",
+    "selectionBackground": "#33467c",
+    "white": "#a9b1d6",
+    "yellow": "#e0af68"
+}

--- a/extras/windows_terminal/tokyonight_storm.json
+++ b/extras/windows_terminal/tokyonight_storm.json
@@ -1,0 +1,25 @@
+# Add the following object to your Windows Terminal configuration
+# https://learn.microsoft.com/en-us/windows/terminal/customize-settings/color-schemes#creating-your-own-color-scheme
+{
+    "background": "#24283b",
+    "black": "#1d202f",
+    "blue": "#7aa2f7",
+    "brightBlack": "#414868",
+    "brightBlue": "#7aa2f7",
+    "brightCyan": "#7dcfff",
+    "brightGreen": "#9ece6a",
+    "brightPurple": "#9d7cd8",
+    "brightRed": "#f7768e",
+    "brightWhite": "#c0caf5",
+    "brightYellow": "#e0af68",
+    "cursorColor": "#c0caf5",
+    "cyan": "#7dcfff",
+    "foreground": "#c0caf5",
+    "green": "#9ece6a",
+    "name": "Tokyo Night Storm",
+    "purple": "#bb9af7",
+    "red": "#f7768e",
+    "selectionBackground": "#364a82",
+    "white": "#a9b1d6",
+    "yellow": "#e0af68"
+}

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -30,6 +30,7 @@ function M.setup()
     delta = "gitconfig",
     terminator = "conf",
     prism = "js",
+    windows_terminal = "json",
   }
   -- map of style to style name
   local styles = {

--- a/lua/tokyonight/extra/windows_terminal.lua
+++ b/lua/tokyonight/extra/windows_terminal.lua
@@ -1,0 +1,40 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @param colors ColorScheme
+function M.generate(colors)
+  local windows_terminal = util.template([[
+# Add the following object to your Windows Terminal configuration
+# https://learn.microsoft.com/en-us/windows/terminal/customize-settings/color-schemes#creating-your-own-color-scheme
+{
+    "background": "${bg}",
+    "black": "${black}",
+    "blue": "${blue}",
+    "brightBlack": "${terminal_black}",
+    "brightBlue": "${blue}",
+    "brightCyan": "${cyan}",
+    "brightGreen": "${green}",
+    "brightPurple": "${purple}",
+    "brightRed": "${red}",
+    "brightWhite": "${fg}",
+    "brightYellow": "${yellow}",
+    "cursorColor": "${fg}",
+    "cyan": "${cyan}",
+    "foreground": "${fg}",
+    "green": "${green}",
+    "name": "${_style_name}",
+    "purple": "${magenta}",
+    "red": "${red}",
+    "selectionBackground": "${bg_visual}",
+    "white": "${fg_dark}",
+    "yellow": "${yellow}"
+}
+]],
+    colors
+  )
+
+  return windows_terminal
+end
+
+return M


### PR DESCRIPTION
Hey, I recently started working in a Windows environment and couldn't live without neovim. I ported the kitty colors to Windows Terminal, have been testing Storm and Day for a bit now and everything seems good so far.