### PR TITLE
Add support for terminals that do not support true color

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ extra themes for Kitty, Alacritty, iTerm and Fish.
 
 ![image](https://user-images.githubusercontent.com/292349/115996270-78c6c480-a593-11eb-8ed0-7d1400b058f5.png)
 
+## Apple terminal fixes
+
+This differs from [folke/tokyonight.nvim](https://github.com/folke/tokyonight.nvim) only in that it supports
+terminals which do not have true color support.  Eg:
+
+<img width="1534" alt="With changes" src="https://user-images.githubusercontent.com/2169888/222120555-009417ca-04de-46c8-b192-8b3b8020072b.png">
+
+vs
+
+<img width="1538" alt="Before changes" src="https://user-images.githubusercontent.com/2169888/222120841-ac0d91c9-4c00-4332-b4fa-6906dd220486.png">
+
+
 ## ✨ Features
 
 - supports the latest Neovim 5.0 features like TreeSitter and LSP
@@ -31,6 +43,7 @@ extra themes for Kitty, Alacritty, iTerm and Fish.
   [Alacritty](https://github.com/alacritty/alacritty) and
   [Fish Shell](https://fishshell.com/)
 - **lualine** theme
+- **support for low palette terminals like Apple's Terminal.app**
 
 ### Plugin Support
 

--- a/lua/barbecue/theme/tokyonight.lua
+++ b/lua/barbecue/theme/tokyonight.lua
@@ -39,4 +39,9 @@ local M = {
   context_type_parameter = { fg = c.green1 },
 }
 
+if config.limited_colors and vim.fn.has('gui_running') ~= 1 then
+    local termcol = require("tokyonight.termcol")
+    M = termcol.map_highlights(M)
+end
+
 return M

--- a/lua/lightline/colorscheme/tokyonight.lua
+++ b/lua/lightline/colorscheme/tokyonight.lua
@@ -35,4 +35,9 @@ tokyonight.tabline = {
   tabsel = { { colors.blue, colors.fg_gutter }, { colors.dark3, colors.bg } },
 }
 
+if config.limited_colors and vim.fn.has('gui_running') ~= 1 then
+    local termcol = require("tokyonight.termcol")
+    tokyonight = termcol.map_highlights(tokyonight)
+end
+
 return tokyonight

--- a/lua/lualine/themes/tokyonight.lua
+++ b/lua/lualine/themes/tokyonight.lua
@@ -46,4 +46,9 @@ if config.lualine_bold then
   end
 end
 
+if config.limited_colors and vim.fn.has('gui_running') ~= 1 then
+    local termcol = require("tokyonight.termcol")
+    tokyonight = termcol.map_highlights(tokyonight)
+end
+
 return tokyonight

--- a/lua/tokyonight/colors.lua
+++ b/lua/tokyonight/colors.lua
@@ -80,6 +80,7 @@ M.moon = function()
     teal = "#4fd6be", --
     red = "#ff757f", --
     red1 = "#c53b53", --
+    white = "#ffffff",
   }
   ret.comment = util.blend(ret.comment, ret.bg, "bb")
   ret.git = {
@@ -152,6 +153,12 @@ function M.setup(opts)
   config.options.on_colors(colors)
   if opts.transform and config.is_day() then
     util.invert_colors(colors)
+  end
+
+  -- must be last
+  if config.options.limited_colors and vim.fn.has('gui_running') ~= 1 then
+    local termcol = require("tokyonight.termcol")
+    return termcol.map_colors(colors)
   end
 
   return colors

--- a/lua/tokyonight/config.lua
+++ b/lua/tokyonight/config.lua
@@ -8,6 +8,7 @@ local defaults = {
   light_style = "day", -- The theme is used when the background is set to light
   transparent = false, -- Enable this to disable setting the background color
   terminal_colors = true, -- Configure the colors used when opening a `:terminal` in Neovim
+  limited_colors = false, -- Use limited palette colors
   styles = {
     -- Style to be applied to different syntax groups
     -- Value is any valid attr-list value for `:help nvim_set_hl`

--- a/lua/tokyonight/termcol.lua
+++ b/lua/tokyonight/termcol.lua
@@ -1,0 +1,162 @@
+local M = {}
+
+-- check for empty colors
+function M.is_empty_or_none(s)
+  return s == nil or s == "NONE" or s == ''
+end
+
+-- returns an approximate grey index for the given grey level
+function M.grey_number(x)
+    if x < 14 then
+        return 0
+    else
+        local n = math.floor((x - 8) / 10)
+        local m = (x - 8) % 10
+        if m < 5 then
+            return n
+        else
+           return n + 1
+        end
+    end
+end
+
+-- returns the actual grey level represented by the grey index
+function M.grey_level(n)
+    if n == 0 then
+        return 0
+    else
+        return 8 + (n * 10)
+    end
+end
+
+-- returns the palette index for the given grey index
+function M.grey_color(n)
+    if n == 0 then
+        return 16
+    elseif n == 25 then
+        return 231
+    else
+        return 231 + n
+    end
+end
+
+-- returns an approximate color index for the given color level
+function M.rgb_number(x)
+    if x < 75 then
+        return 0
+    else
+        local n = math.floor((x - 55) / 40)
+        local m = (x - 55) % 40
+        if m < 20 then
+            return n
+        else
+            return n + 1
+        end
+    end
+end
+
+-- returns the actual color level for the given color index
+function M.rgb_level(n)
+    if n == 0 then
+        return 0
+    else
+        return 55 + (n * 40)
+    end
+end
+
+--  returns the palette index for the given R/G/B color indices
+function M.rgb_color(x, y, z)
+    return 16 + (x * 36) + (y * 6) + z
+end
+
+-- returns the palette index to approximate the given R/G/B color levels
+function M.color(r, g, b)
+  -- map greys directly (see xterm's 256colres.pl)
+  if vim.o.t_Co == 256 and r == g and g == b and r > 3 and r < 243 then
+    return math.floor((r - 8) / 10) + 232
+  end
+
+  -- get the closest grey
+  local gx = M.grey_number(r)
+  local gy = M.grey_number(g)
+  local gz = M.grey_number(b)
+
+  -- get the closest color
+  local x = M.rgb_number(r)
+  local y = M.rgb_number(g)
+  local z = M.rgb_number(b)
+
+  if gx == gy and gy == gz then
+    -- there are two possibilities
+    local dgr = M.grey_level(gx) - r
+    local dgg = M.grey_level(gy) - g
+    local dgb = M.grey_level(gz) - b
+    local dgrey = (dgr * dgr) + (dgg * dgg) + (dgb * dgb)
+    local dr = M.rgb_level(gx) - r
+    local dg = M.rgb_level(gy) - g
+    local db = M.rgb_level(gz) - b
+    local drgb = (dr * dr) + (dg * dg) + (db * db)
+    if dgrey < drgb then
+      -- use the grey
+      return M.grey_color(gx)
+    else
+      -- use the color
+      return M.rgb_color(x, y, z)
+    end
+  else
+    -- only one possibility
+    return M.rgb_color(x, y, z)
+  end
+end
+
+-- returns the palette index to approximate the 'rrggbb' hex string
+---@param rgb string color
+function M.rgb(rgb)
+  if M.is_empty_or_none(rgb) then
+    return 'NONE'
+  end
+  local r = ("0x" .. string.sub(rgb, 2, 3)) + 0
+  local g = ("0x" .. string.sub(rgb, 4, 5)) + 0
+  local b = ("0x" .. string.sub(rgb, 6, 7)) + 0
+  return M.color(r, g, b)
+end
+
+---@param colors Palette
+function M.map_colors(colors)
+  local ret = {}
+  if type(colors) == "string" then
+    ---@diagnostic disable-next-line: return-type-mismatch
+    return M.rgb(colors)
+  end
+  for key, value in pairs(colors) do
+    ret[key] = M.map_colors(value)
+  end
+  return ret
+end
+
+---@param highlights table
+function M.map_highlight(highlights)
+  local ret = {}
+  for key, value in pairs(highlights) do
+    if key == 'fg' then
+        key = 'ctermfg'
+    elseif key == 'bg' then
+        key = 'ctermbg'
+    end
+    ret[key] = value
+  end
+  return ret
+end
+
+---@param highlights table
+function M.map_highlights(highlights)
+  local ret = {}
+  for key, value in pairs(highlights) do
+    ret[key] = M.map_highlight(value)
+  end
+  return ret
+end
+
+
+return M
+

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -642,7 +642,7 @@ function M.setup()
     MiniIndentscopeSymbol = { fg = c.blue1 },
     MiniIndentscopePrefix = { nocombine = true }, -- Make it invisible
 
-    MiniJump = { bg = c.magenta2, fg = "#ffffff" },
+    MiniJump = { bg = c.magenta2, fg = c.white },
 
     MiniJump2dSpot = { fg = c.magenta2, bold = true, nocombine = true },
 
@@ -759,6 +759,12 @@ function M.setup()
   if config.is_day() then
     util.invert_colors(theme.colors)
     util.invert_highlights(theme.highlights)
+  end
+
+  -- must be last
+  if config.options.limited_colors and vim.fn.has('gui_running') ~= 1 then
+    local termcol = require("tokyonight.termcol")
+    theme.highlights = termcol.map_highlights(theme.highlights)
   end
 
   return theme

--- a/lua/tokyonight/util.lua
+++ b/lua/tokyonight/util.lua
@@ -29,10 +29,16 @@ function M.blend(foreground, background, alpha)
 end
 
 function M.darken(hex, amount, bg)
+  if type(hex) ~= "string" then
+      return hex
+  end
   return M.blend(hex, bg or M.bg, amount)
 end
 
 function M.lighten(hex, amount, fg)
+  if type(hex) ~= "string" then
+      return hex
+  end
   return M.blend(hex, fg or M.fg, amount)
 end
 
@@ -176,7 +182,9 @@ function M.load(theme)
     vim.cmd("hi clear")
   end
 
-  vim.o.termguicolors = true
+  if not theme.config.limited_colors or vim.fn.has('gui_running') == 1 then
+    vim.o.termguicolors = true
+  end
   vim.g.colors_name = "tokyonight"
 
   if ts.new_style() then


### PR DESCRIPTION
Use conversion functions to map to `ctermfg` and `ctermbg` when gui is not active and `limited_colors` config option is set.

This enables use of TokyoNight in Apple Terminal.