### PR TITLE
feat(semantic_tokens): link lsp comments, e.g. conditional C ifdefs that won't evaluate

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -254,9 +254,10 @@ function M.setup()
     ["@namespace"] = { link = "Include" },
 
     -- LSP Semantic Token Groups
+    ["@lsp.type.comment"] = { link = "@comment" },
     ["@lsp.type.enum"] = { link = "@type" },
-    ["@lsp.type.keyword"] = { link = "@keyword" },
     ["@lsp.type.interface"] = { link = "Identifier" },
+    ["@lsp.type.keyword"] = { link = "@keyword" },
     ["@lsp.type.namespace"] = { link = "@namespace" },
     ["@lsp.type.parameter"] = { link = "@parameter" },
     ["@lsp.type.property"] = { link = "@property" },


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/29718261/224625356-4f4e7394-662a-4b55-bc50-a7d4c2354073.png)

After:
![image](https://user-images.githubusercontent.com/29718261/224625551-ffd070d2-7bcb-43b2-8be5-5e8beb241a60.png)

Would be very useful for C/C++ devs