### PR TITLE
feat(lsp): set injected highlights

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -264,7 +264,10 @@ function M.setup()
     ["@lsp.type.variable"] = {}, -- use treesitter styles for regular variables
     ["@lsp.typemod.method.defaultLibrary"] = { link = "@function.builtin" },
     ["@lsp.typemod.function.defaultLibrary"] = { link = "@function.builtin" },
+    ["@lsp.typemod.operator.injected"] = { link = "@operator" },
+    ["@lsp.typemod.string.injected"] = { link = "@string" },
     ["@lsp.typemod.variable.defaultLibrary"] = { link = "@variable.builtin" },
+    ["@lsp.typemod.variable.injected"] = { link = "@variable" },
     -- NOTE: maybe add these with distinct highlights?
     -- ["@lsp.typemod.variable.globalScope"] (global variables)
 


### PR DESCRIPTION
This is mainly for Rust doc comments, and would work for other lsps that injects tokens in comments

Before:
![image](https://user-images.githubusercontent.com/29718261/227109024-f9e02f75-03ca-4b65-94ff-99889e2128db.png)

After:
![image](https://user-images.githubusercontent.com/29718261/227108761-6c714182-0170-4f08-a05a-4bdc48984426.png)
