### PR TITLE
Make generation of extras deterministic

### DIFF
--- a/lua/tokyonight/colors.lua
+++ b/lua/tokyonight/colors.lua
@@ -108,7 +108,7 @@ function M.setup(opts)
 
   -- Color Palette
   ---@class ColorScheme: Palette
-  local colors = vim.tbl_deep_extend("force", vim.deepcopy(M.default), palette)
+  local colors = vim.tbl_deep_extend("force", {}, M.default, palette)
 
   util.bg = colors.bg
   util.day_brightness = config.options.day_brightness

--- a/lua/tokyonight/colors.lua
+++ b/lua/tokyonight/colors.lua
@@ -108,7 +108,7 @@ function M.setup(opts)
 
   -- Color Palette
   ---@class ColorScheme: Palette
-  local colors = vim.tbl_deep_extend("force", M.default, palette)
+  local colors = vim.tbl_deep_extend("force", vim.deepcopy(M.default), palette)
 
   util.bg = colors.bg
   util.day_brightness = config.options.day_brightness


### PR DESCRIPTION
While working on https://github.com/folke/tokyonight.nvim/issues/256, I noticed that generating extras was not deterministic. Specifically, I would expect that running this command from the repo root repeatedly would only cause the files to change once:

```shell
nvim --headless +'lua package.path = "./lua/?.lua;" .. package.path; require("tokyonight/extra/init").setup()' +q
```

Instead, this causes the git diff colors (and a few others) to oscillate between values, depending on if the day theme is built before or after the other themes.

This PR fixes the issue. I'm still not quite sure why it was happening, I am not fluent in Lua.