### PR TITLE
Fix lsp highlight group

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -257,7 +257,7 @@ function M.setup()
     ["@lsp.type.comment"] = { link = "@comment" },
     ["@lsp.type.enum"] = { link = "@type" },
     ["@lsp.type.enumMember"] = { link = "@property" },
-    ["@lsp.type.interface"] = { link = "Identifier" },
+    ["@lsp.type.interface"] = { link = "@type" },
     ["@lsp.type.keyword"] = { link = "@keyword" },
     ["@lsp.type.namespace"] = { link = "@namespace" },
     ["@lsp.type.parameter"] = { link = "@parameter" },

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -256,6 +256,7 @@ function M.setup()
     -- LSP Semantic Token Groups
     ["@lsp.type.comment"] = { link = "@comment" },
     ["@lsp.type.enum"] = { link = "@type" },
+    ["@lsp.type.enumMember"] = { link = "@property" },
     ["@lsp.type.interface"] = { link = "Identifier" },
     ["@lsp.type.keyword"] = { link = "@keyword" },
     ["@lsp.type.namespace"] = { link = "@namespace" },


### PR DESCRIPTION
1. Link the `@lsp.type.enumMember` to `@property`.
2. Link the `@lsp.type.interface` to `@type`.

Close https://github.com/folke/tokyonight.nvim/issues/347