### PR TITLE
fix(semantic_tokens): reset comment type

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -257,7 +257,7 @@ function M.setup()
     ["@namespace"] = { link = "Include" },
 
     -- LSP Semantic Token Groups
-    ["@lsp.type.comment"] = { link = "@comment" },
+    ["@lsp.type.comment"] = {},
     ["@lsp.type.enum"] = { link = "@type" },
     ["@lsp.type.enumMember"] = { link = "@constant" },
     ["@lsp.type.interface"] = { fg = util.lighten(c.blue1, 0.7) },


### PR DESCRIPTION
Linking `@lsp.type.comment` to `Comment` or `@comment` makes TODO comments a bit harder to read.

Before

![20230418_201229](https://user-images.githubusercontent.com/55179750/232778521-55c8297d-1a29-413f-b70a-f67eff416219.jpeg)

After

![20230418_201339](https://user-images.githubusercontent.com/55179750/232778597-670d71c1-72e8-4580-8829-fdeb4bd20fe1.jpeg)
