### PR TITLE
feat(treesitter): darken builtin types & revert reset comment type

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -234,6 +234,7 @@ function M.setup()
     ["@label"] = { fg = c.blue }, -- For labels: `label:` in C and `:label:` in Lua.
 
     --- Types
+    ["@type.builtin"] = { fg = util.darken(c.blue1, 0.8) },
     ["@field"] = { fg = c.green1 }, -- For fields.
     ["@property"] = { fg = c.green1 },
 

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -258,7 +258,7 @@ function M.setup()
     ["@namespace"] = { link = "Include" },
 
     -- LSP Semantic Token Groups
-    ["@lsp.type.comment"] = {},
+    ["@lsp.type.comment"] = { link = "@comment" },
     ["@lsp.type.enum"] = { link = "@type" },
     ["@lsp.type.enumMember"] = { link = "@constant" },
     ["@lsp.type.interface"] = { fg = util.lighten(c.blue1, 0.7) },


### PR DESCRIPTION
Linking lsp comments to comment were very useful for c/c++ and other languages with conditional compilation directives being "commented" out if inactive