### PR TITLE
LSP macro

### DIFF
--- a/extras/lua/tokyonight_day.lua
+++ b/extras/lua/tokyonight_day.lua
@@ -111,6 +111,9 @@ local highlights = {
   ["@lsp.typemod.function.defaultLibrary"] = {
     link = "@function.builtin"
   },
+  ["@lsp.typemod.macro.defaultLibrary"] = {
+    link = "@function.builtin"
+  },
   ["@lsp.typemod.method.defaultLibrary"] = {
     link = "@function.builtin"
   },

--- a/extras/lua/tokyonight_moon.lua
+++ b/extras/lua/tokyonight_moon.lua
@@ -111,6 +111,9 @@ local highlights = {
   ["@lsp.typemod.function.defaultLibrary"] = {
     link = "@function.builtin"
   },
+  ["@lsp.typemod.macro.defaultLibrary"] = {
+    link = "@function.builtin"
+  },
   ["@lsp.typemod.method.defaultLibrary"] = {
     link = "@function.builtin"
   },

--- a/extras/lua/tokyonight_night.lua
+++ b/extras/lua/tokyonight_night.lua
@@ -111,6 +111,9 @@ local highlights = {
   ["@lsp.typemod.function.defaultLibrary"] = {
     link = "@function.builtin"
   },
+  ["@lsp.typemod.macro.defaultLibrary"] = {
+    link = "@function.builtin"
+  },
   ["@lsp.typemod.method.defaultLibrary"] = {
     link = "@function.builtin"
   },

--- a/extras/lua/tokyonight_storm.lua
+++ b/extras/lua/tokyonight_storm.lua
@@ -111,6 +111,9 @@ local highlights = {
   ["@lsp.typemod.function.defaultLibrary"] = {
     link = "@function.builtin"
   },
+  ["@lsp.typemod.macro.defaultLibrary"] = {
+    link = "@function.builtin"
+  },
   ["@lsp.typemod.method.defaultLibrary"] = {
     link = "@function.builtin"
   },

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -267,11 +267,12 @@ function M.setup()
     ["@lsp.type.parameter"] = { link = "@parameter" },
     ["@lsp.type.property"] = { link = "@property" },
     ["@lsp.type.variable"] = {}, -- use treesitter styles for regular variables
-    ["@lsp.typemod.method.defaultLibrary"] = { link = "@function.builtin" },
-    ["@lsp.typemod.type.defaultLibrary"] = { fg = util.darken(c.blue1, 0.8) },
     ["@lsp.typemod.function.defaultLibrary"] = { link = "@function.builtin" },
+    ["@lsp.typemod.macro.defaultLibrary"] = { link = "@function.builtin" },
+    ["@lsp.typemod.method.defaultLibrary"] = { link = "@function.builtin" },
     ["@lsp.typemod.operator.injected"] = { link = "@operator" },
     ["@lsp.typemod.string.injected"] = { link = "@string" },
+    ["@lsp.typemod.type.defaultLibrary"] = { fg = util.darken(c.blue1, 0.8) },
     ["@lsp.typemod.variable.defaultLibrary"] = { link = "@variable.builtin" },
     ["@lsp.typemod.variable.injected"] = { link = "@variable" },
     -- NOTE: maybe add these with distinct highlights?


### PR DESCRIPTION
For the latter (macro), an example could be Rust's "println!" macro, where `@function.builtin` would be much nicer :grin: 

Edit: removed conditional as items like return are marked conditional in Rust's lsp..bizarre