### PR TITLE
Correct brighten to lighten in README and doc code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ local colors = require("tokyonight.colors").setup() -- pass in any of the config
 local util = require("tokyonight.util")
 
 aplugin.background = colors.bg_dark
-aplugin.my_error = util.brighten(colors.red1, 0.3)
+aplugin.my_error = util.lighten(colors.red1, 0.3) -- number between 0 and 1. 0 results in white, 1 results in red1
 ```
 
 ## 🔥 Contributing

--- a/doc/tokyonight.nvim.txt
+++ b/doc/tokyonight.nvim.txt
@@ -294,7 +294,7 @@ config:
     local util = require("tokyonight.util")
     
     aplugin.background = colors.bg_dark
-    aplugin.my_error = util.brighten(colors.red1, 0.3)
+    aplugin.my_error = util.lighten(colors.red1, 0.3) -- number between 0 and 1. 0 results in white, 1 results in red1
 <
 
 


### PR DESCRIPTION
This util method seems like it used to be called `brighten`, but was never updated in the README or doc.

I also added a comment to explain how `lighten` works.