### PR TITLE
docs: fix install instruction for lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Install the theme with your preferred package manager:
 
 ```lua
 {
-  "tokyonight.nvim",
+  "folke/tokyonight.nvim",
   lazy = false,
   priority = 1000,
   opts = {},


### PR DESCRIPTION
I get this error after following the readme:

Plugin spec for **tokyonight.nvim** not found.
```lua
{ "tokyonight.nvim",
  _ = {},
  lazy = false,
  name = "tokyonight.nvim",
  opts = {},
  priority = 1000
}
```

Should be `folke/tokyonight.nvim` instead.