### PR TITLE
fix(mini-indentscope): symbol hl group nocombine

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -683,7 +683,7 @@ function M.setup()
     MiniCursorword = { bg = c.fg_gutter },
     MiniCursorwordCurrent = { bg = c.fg_gutter },
 
-    MiniIndentscopeSymbol = { fg = c.blue1 },
+    MiniIndentscopeSymbol = { fg = c.blue1, nocombine = true },
     MiniIndentscopePrefix = { nocombine = true }, -- Make it invisible
 
     MiniJump = { bg = c.magenta2, fg = "#ffffff" },


### PR DESCRIPTION
This fixes the indent symbol being italicized when it lands within another italicized region (such as a comment).