### PR TITLE
fix(dunst): make whitespace consistent

### DIFF
--- a/lua/tokyonight/extra/dunst.lua
+++ b/lua/tokyonight/extra/dunst.lua
@@ -12,12 +12,12 @@ function M.generate(colors)
 [urgency_low]
     background = "${bg_dark}"
     foreground = "${fg}"
-	frame_color = "${fg}"
+    frame_color = "${fg}"
 
 [urgency_normal]
     background = "${bg}"
     foreground = "${fg}"
-	frame_color = "${fg}"
+    frame_color = "${fg}"
 
 [urgency_critical]
     background = "${bg_highlight}"


### PR DESCRIPTION
The `dunst` extra file has inconsistent whitespace: some are spaces while some are tabs. This PR makes them consistent.
