### PR TITLE
Added rainbow-delimiter highlight groups

### DIFF
--- a/extras/lua/tokyonight_day.lua
+++ b/extras/lua/tokyonight_day.lua
@@ -1583,6 +1583,27 @@ local highlights = {
     bg = "#b6bfe2",
     bold = true
   },
+  RainbowDelimiterBlue = {
+    fg = "#2e7de9"
+  },
+  RainbowDelimiterCyan = {
+    fg = "#007197"
+  },
+  RainbowDelimiterGreen = {
+    fg = "#587539"
+  },
+  RainbowDelimiterOrange = {
+    fg = "#b15c00"
+  },
+  RainbowDelimiterRed = {
+    fg = "#f52a65"
+  },
+  RainbowDelimiterViolet = {
+    fg = "#7847bd"
+  },
+  RainbowDelimiterYellow = {
+    fg = "#8c6c3e"
+  },
   ReferencesCount = {
     fg = "#7847bd"
   },

--- a/extras/lua/tokyonight_moon.lua
+++ b/extras/lua/tokyonight_moon.lua
@@ -1583,6 +1583,27 @@ local highlights = {
     bg = "#2d3f76",
     bold = true
   },
+  RainbowDelimiterBlue = {
+    fg = "#82aaff"
+  },
+  RainbowDelimiterCyan = {
+    fg = "#86e1fc"
+  },
+  RainbowDelimiterGreen = {
+    fg = "#c3e88d"
+  },
+  RainbowDelimiterOrange = {
+    fg = "#ff966c"
+  },
+  RainbowDelimiterRed = {
+    fg = "#ff757f"
+  },
+  RainbowDelimiterViolet = {
+    fg = "#fca7ea"
+  },
+  RainbowDelimiterYellow = {
+    fg = "#ffc777"
+  },
   ReferencesCount = {
     fg = "#fca7ea"
   },

--- a/extras/lua/tokyonight_night.lua
+++ b/extras/lua/tokyonight_night.lua
@@ -1583,6 +1583,27 @@ local highlights = {
     bg = "#283457",
     bold = true
   },
+  RainbowDelimiterBlue = {
+    fg = "#7aa2f7"
+  },
+  RainbowDelimiterCyan = {
+    fg = "#7dcfff"
+  },
+  RainbowDelimiterGreen = {
+    fg = "#9ece6a"
+  },
+  RainbowDelimiterOrange = {
+    fg = "#ff9e64"
+  },
+  RainbowDelimiterRed = {
+    fg = "#f7768e"
+  },
+  RainbowDelimiterViolet = {
+    fg = "#9d7cd8"
+  },
+  RainbowDelimiterYellow = {
+    fg = "#e0af68"
+  },
   ReferencesCount = {
     fg = "#9d7cd8"
   },

--- a/extras/lua/tokyonight_storm.lua
+++ b/extras/lua/tokyonight_storm.lua
@@ -1583,6 +1583,27 @@ local highlights = {
     bg = "#2e3c64",
     bold = true
   },
+  RainbowDelimiterBlue = {
+    fg = "#7aa2f7"
+  },
+  RainbowDelimiterCyan = {
+    fg = "#7dcfff"
+  },
+  RainbowDelimiterGreen = {
+    fg = "#9ece6a"
+  },
+  RainbowDelimiterOrange = {
+    fg = "#ff9e64"
+  },
+  RainbowDelimiterRed = {
+    fg = "#f7768e"
+  },
+  RainbowDelimiterViolet = {
+    fg = "#9d7cd8"
+  },
+  RainbowDelimiterYellow = {
+    fg = "#e0af68"
+  },
   ReferencesCount = {
     fg = "#9d7cd8"
   },

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -317,6 +317,15 @@ function M.setup()
     TSRainbowViolet = { fg = c.purple },
     TSRainbowCyan = { fg = c.cyan },
 
+    -- rainbow-delimiters
+    RainbowDelimiterRed = { fg = c.red },
+    RainbowDelimiterOrange = { fg = c.orange },
+    RainbowDelimiterYellow = { fg = c.yellow },
+    RainbowDelimiterGreen = { fg = c.green },
+    RainbowDelimiterBlue = { fg = c.blue },
+    RainbowDelimiterViolet = { fg = c.purple },
+    RainbowDelimiterCyan = { fg = c.cyan },
+
     -- LspTrouble
     TroubleText = { fg = c.fg_dark },
     TroubleCount = { fg = c.magenta, bg = c.fg_gutter },


### PR DESCRIPTION
The plugin https://github.com/HiPhish/nvim-ts-rainbow2 is being deprecated due to treesitter dropping modules support, so https://github.com/HiPhish/rainbow-delimiters.nvim is going to be the newly maintained one. You can find the deprecation notice here: https://github.com/HiPhish/nvim-ts-rainbow2/commit/d6e82e23f877f488563437237abbc85d7cededea

This PR adds support for the new highlight groups being used by rainbow-delimiters.nvim.

With that being said, rainbow-delimiters.nvim looks like it's undergoing a lot of development, so I can see reasons for not merging this just yet.

