### PR TITLE
fix(kitty): Make text on fg selection readable again

### DIFF
--- a/extras/kitty/tokyonight_day.conf
+++ b/extras/kitty/tokyonight_day.conf
@@ -46,5 +46,5 @@ color14 #007197
 color15 #3760bf
 
 # extended colors
-color16 #b15c00
+color16 #e9e9ed
 color17 #c64343

--- a/extras/kitty/tokyonight_moon.conf
+++ b/extras/kitty/tokyonight_moon.conf
@@ -46,5 +46,5 @@ color14 #86e1fc
 color15 #c8d3f5
 
 # extended colors
-color16 #ff966c
+color16 #1b1d2b
 color17 #c53b53

--- a/extras/kitty/tokyonight_night.conf
+++ b/extras/kitty/tokyonight_night.conf
@@ -46,5 +46,5 @@ color14 #7dcfff
 color15 #c0caf5
 
 # extended colors
-color16 #ff9e64
+color16 #15161e
 color17 #db4b4b

--- a/extras/kitty/tokyonight_storm.conf
+++ b/extras/kitty/tokyonight_storm.conf
@@ -46,5 +46,5 @@ color14 #7dcfff
 color15 #c0caf5
 
 # extended colors
-color16 #ff9e64
+color16 #1d202f
 color17 #db4b4b


### PR DESCRIPTION
The old behavior was tough to read when having a text in a foreground:

Old behavior:
![image](https://github.com/folke/tokyonight.nvim/assets/17012133/4de2df83-9e82-4573-a24d-4c7f9d0cc1f7)


New behavior:

![image](https://github.com/folke/tokyonight.nvim/assets/17012133/fdfa4d31-9000-400f-854d-76c0834b0dbb)

PS: I settled to just default to a black font here again, which seems like a sane default. Happy to change this to a color that'd be more appropriate for tokyonight :)