### PR TITLE
feat(extras): add fzf colors

### DIFF
--- a/lua/tokyonight/extra/fzf.lua
+++ b/lua/tokyonight/extra/fzf.lua
@@ -8,11 +8,11 @@ function M.generate(colors)
 end
 
 M.template = [[
-export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS'
---color=fg:${fg},bg:${bg},hl:${orange}
---color=fg+:${fg},bg+:${bg_highlight},hl+:${orange}
---color=info:${blue},prompt:${cyan},pointer:${cyan}
---color=marker:${green},spinner:${green},header:${green}'"
+export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS \
+--color=fg:${fg},bg:${bg},hl:${orange} \ 
+--color=fg+:${fg},bg+:${bg_highlight},hl+:${orange} \
+--color=info:${blue},prompt:${cyan},pointer:${cyan} \
+--color=marker:${green},spinner:${green},header:${green}"
 ]]
 
 return M

--- a/lua/tokyonight/extra/fzf.lua
+++ b/lua/tokyonight/extra/fzf.lua
@@ -1,0 +1,18 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @param colors ColorScheme
+function M.generate(colors)
+  return util.template(M.template, colors)
+end
+
+M.template = [[
+export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS'
+--color=fg:${fg},bg:${bg},hl:${orange}
+--color=fg+:${fg},bg+:${bg_highlight},hl+:${orange}
+--color=info:${blue},prompt:${cyan},pointer:${cyan}
+--color=marker:${green},spinner:${green},header:${green}'"
+]]
+
+return M

--- a/lua/tokyonight/extra/fzf.lua
+++ b/lua/tokyonight/extra/fzf.lua
@@ -9,7 +9,7 @@ end
 
 M.template = [[
 export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS \
---color=fg:${fg},bg:${bg},hl:${orange} \ 
+--color=fg:${fg},bg:${bg},hl:${orange} \
 --color=fg+:${fg},bg+:${bg_highlight},hl+:${orange} \
 --color=info:${blue},prompt:${cyan},pointer:${cyan} \
 --color=marker:${green},spinner:${green},header:${green}"

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -25,6 +25,8 @@ M.extras = {
   dunst = {ext = "dunstrc", url = "https://dunst-project.org/", label = "Dunst"},
   gitui = {ext = "ron", url = "https://github.com/extrawurst/gitui", label = "GitUI"},
   helix = { ext = "toml", url = "https://helix-editor.com/", label = "Helix"},
+  fzf = { ext = "zsh", url = "https://github.com/junegunn/fzf", label = "Fzf"},
+
 }
 
 local function write(str, fileName)

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -26,7 +26,6 @@ M.extras = {
   gitui = {ext = "ron", url = "https://github.com/extrawurst/gitui", label = "GitUI"},
   helix = { ext = "toml", url = "https://helix-editor.com/", label = "Helix"},
   fzf = { ext = "zsh", url = "https://github.com/junegunn/fzf", label = "Fzf"},
-
 }
 
 local function write(str, fileName)


### PR DESCRIPTION
This PR generates themes for fzf in a format of `env_var` that appends new colors to the existing `FZF_DEFAULT_OPTS` value.