### PR TITLE
fix: readd `@punctuation.special`

### DIFF
--- a/extras/lua/tokyonight_day.lua
+++ b/extras/lua/tokyonight_day.lua
@@ -427,6 +427,9 @@ local highlights = {
   ["@punctuation.delimiter"] = {
     fg = "#006a83"
   },
+  ["@punctuation.special"] = {
+    fg = "#006a83",
+  },
   ["@string"] = {
     link = "String"
   },

--- a/extras/lua/tokyonight_moon.lua
+++ b/extras/lua/tokyonight_moon.lua
@@ -427,6 +427,9 @@ local highlights = {
   ["@punctuation.delimiter"] = {
     fg = "#89ddff"
   },
+  ["@punctuation.special"] = {
+    fg = "#89ddff",
+  },
   ["@string"] = {
     link = "String"
   },

--- a/extras/lua/tokyonight_night.lua
+++ b/extras/lua/tokyonight_night.lua
@@ -427,6 +427,9 @@ local highlights = {
   ["@punctuation.delimiter"] = {
     fg = "#89ddff"
   },
+  ["@punctuation.special"] = {
+    fg = "#89ddff",
+  },
   ["@string"] = {
     link = "String"
   },

--- a/extras/lua/tokyonight_storm.lua
+++ b/extras/lua/tokyonight_storm.lua
@@ -427,6 +427,9 @@ local highlights = {
   ["@punctuation.delimiter"] = {
     fg = "#89ddff"
   },
+  ["@punctuation.special"] = {
+    fg = "#89ddff",
+  },
   ["@string"] = {
     link = "String"
   },

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -273,6 +273,7 @@ function M.setup()
     --- Punctuation
     ["@punctuation.delimiter"] = { fg = c.blue5 }, -- For delimiters ie: `.`
     ["@punctuation.bracket"] = { fg = c.fg_dark }, -- For brackets and parens.
+    ["@punctuation.special"] = { fg = c.blue5 }, -- For special symbols (e.g. `{}` in string interpolation)
     ["@markup.list"] = { fg = c.blue5 }, -- For special punctutation that does not fall in the catagories before.
     ["@markup.list.markdown"] = { fg = c.orange, bold = true },
 


### PR DESCRIPTION
Pretty much only seen in string interpolation contexts, it was blue5 before so I just used that

before
![image](https://github.com/folke/tokyonight.nvim/assets/29718261/b959f4c4-7874-45a3-bd87-fce65c2bba93)

after
![image](https://github.com/folke/tokyonight.nvim/assets/29718261/031f654b-602d-4e87-a3cc-1a8bf4a46bed)
