### PR TITLE
feat(extras): add GNOME terminal

### DIFF
--- a/extras/gnome_terminal/tokyonight_day.dconf
+++ b/extras/gnome_terminal/tokyonight_day.dconf
@@ -1,0 +1,18 @@
+# Import this theme as follows:
+# 1. Create a new profile for GNOME Terminal
+# 2. Copy the UUID of the new profile (bottom right corner of the preferences window)
+# 3. Replace <PROFILE_UUID> below with the copied UUID
+# 4. Execute `dconf load /org/gnome/terminal/legacy/profiles:/ < tokyonight_day.dconf`
+
+[:<PROFILE_UUID>]
+background-color='rgb(225, 226, 231)'
+cursor-background-color='rgb(55, 96, 191)'
+cursor-colors-set=true
+cursor-foreground-color='rgb(225, 226, 231)'
+foreground-color='rgb(55, 96, 191)'
+highlight-background-color='rgb(55, 96, 191)'
+highlight-colors-set=true
+highlight-foreground-color='rgb(225, 226, 231)'
+palette=['rgb(161, 166, 197)', 'rgb(245, 42, 101)', 'rgb(88, 117, 57)', 'rgb(140, 108, 62)', 'rgb(46, 125, 233)', 'rgb(152, 84, 241)', 'rgb(0, 113, 151)', 'rgb(55, 96, 191)', 'rgb(161, 166, 197)', 'rgb(245, 42, 101)', 'rgb(88, 117, 57)', 'rgb(140, 108, 62)', 'rgb(46, 125, 233)', 'rgb(152, 84, 241)', 'rgb(0, 113, 151)', 'rgb(55, 96, 191)']
+use-theme-colors=false
+visible-name='Tokyo Night Day'

--- a/extras/gnome_terminal/tokyonight_moon.dconf
+++ b/extras/gnome_terminal/tokyonight_moon.dconf
@@ -1,0 +1,18 @@
+# Import this theme as follows:
+# 1. Create a new profile for GNOME Terminal
+# 2. Copy the UUID of the new profile (bottom right corner of the preferences window)
+# 3. Replace <PROFILE_UUID> below with the copied UUID
+# 4. Execute `dconf load /org/gnome/terminal/legacy/profiles:/ < tokyonight_moon.dconf`
+
+[:<PROFILE_UUID>]
+background-color='rgb(34, 36, 54)'
+cursor-background-color='rgb(200, 211, 245)'
+cursor-colors-set=true
+cursor-foreground-color='rgb(34, 36, 54)'
+foreground-color='rgb(200, 211, 245)'
+highlight-background-color='rgb(200, 211, 245)'
+highlight-colors-set=true
+highlight-foreground-color='rgb(34, 36, 54)'
+palette=['rgb(68, 74, 115)', 'rgb(255, 117, 127)', 'rgb(195, 232, 141)', 'rgb(255, 199, 119)', 'rgb(130, 170, 255)', 'rgb(192, 153, 255)', 'rgb(134, 225, 252)', 'rgb(200, 211, 245)', 'rgb(68, 74, 115)', 'rgb(255, 117, 127)', 'rgb(195, 232, 141)', 'rgb(255, 199, 119)', 'rgb(130, 170, 255)', 'rgb(192, 153, 255)', 'rgb(134, 225, 252)', 'rgb(200, 211, 245)']
+use-theme-colors=false
+visible-name='Tokyo Night Moon'

--- a/extras/gnome_terminal/tokyonight_night.dconf
+++ b/extras/gnome_terminal/tokyonight_night.dconf
@@ -1,0 +1,18 @@
+# Import this theme as follows:
+# 1. Create a new profile for GNOME Terminal
+# 2. Copy the UUID of the new profile (bottom right corner of the preferences window)
+# 3. Replace <PROFILE_UUID> below with the copied UUID
+# 4. Execute `dconf load /org/gnome/terminal/legacy/profiles:/ < tokyonight_night.dconf`
+
+[:<PROFILE_UUID>]
+background-color='rgb(26, 27, 38)'
+cursor-background-color='rgb(192, 202, 245)'
+cursor-colors-set=true
+cursor-foreground-color='rgb(26, 27, 38)'
+foreground-color='rgb(192, 202, 245)'
+highlight-background-color='rgb(192, 202, 245)'
+highlight-colors-set=true
+highlight-foreground-color='rgb(26, 27, 38)'
+palette=['rgb(65, 72, 104)', 'rgb(247, 118, 142)', 'rgb(158, 206, 106)', 'rgb(224, 175, 104)', 'rgb(122, 162, 247)', 'rgb(187, 154, 247)', 'rgb(125, 207, 255)', 'rgb(192, 202, 245)', 'rgb(65, 72, 104)', 'rgb(247, 118, 142)', 'rgb(158, 206, 106)', 'rgb(224, 175, 104)', 'rgb(122, 162, 247)', 'rgb(187, 154, 247)', 'rgb(125, 207, 255)', 'rgb(192, 202, 245)']
+use-theme-colors=false
+visible-name='Tokyo Night'

--- a/extras/gnome_terminal/tokyonight_storm.dconf
+++ b/extras/gnome_terminal/tokyonight_storm.dconf
@@ -1,0 +1,18 @@
+# Import this theme as follows:
+# 1. Create a new profile for GNOME Terminal
+# 2. Copy the UUID of the new profile (bottom right corner of the preferences window)
+# 3. Replace <PROFILE_UUID> below with the copied UUID
+# 4. Execute `dconf load /org/gnome/terminal/legacy/profiles:/ < tokyonight_storm.dconf`
+
+[:<PROFILE_UUID>]
+background-color='rgb(36, 40, 59)'
+cursor-background-color='rgb(192, 202, 245)'
+cursor-colors-set=true
+cursor-foreground-color='rgb(36, 40, 59)'
+foreground-color='rgb(192, 202, 245)'
+highlight-background-color='rgb(192, 202, 245)'
+highlight-colors-set=true
+highlight-foreground-color='rgb(36, 40, 59)'
+palette=['rgb(65, 72, 104)', 'rgb(247, 118, 142)', 'rgb(158, 206, 106)', 'rgb(224, 175, 104)', 'rgb(122, 162, 247)', 'rgb(187, 154, 247)', 'rgb(125, 207, 255)', 'rgb(192, 202, 245)', 'rgb(65, 72, 104)', 'rgb(247, 118, 142)', 'rgb(158, 206, 106)', 'rgb(224, 175, 104)', 'rgb(122, 162, 247)', 'rgb(187, 154, 247)', 'rgb(125, 207, 255)', 'rgb(192, 202, 245)']
+use-theme-colors=false
+visible-name='Tokyo Night Storm'

--- a/lua/tokyonight/extra/gnome_terminal.lua
+++ b/lua/tokyonight/extra/gnome_terminal.lua
@@ -1,0 +1,46 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+function M.generate(colors)
+    local gnome_colors = {}
+    for k, v in pairs(colors) do
+        local is_color = type(v) == "string" and v:find("^#[%x]") ~= nil
+        if is_color then
+            local hex = v:gsub("^#", "")
+            local r = tonumber(hex:sub(1, 2), 16)
+            local g = tonumber(hex:sub(3, 4), 16)
+            local b = tonumber(hex:sub(5, 6), 16)
+            gnome_colors[k] = string.format("rgb(%d, %d, %d)", r, g, b)
+        else
+            gnome_colors[k] = v
+        end
+    end
+
+    local gnome_terminal = util.template(
+        [[
+# Import this theme as follows:
+# 1. Create a new profile for GNOME Terminal
+# 2. Copy the UUID of the new profile (bottom right corner of the preferences window)
+# 3. Replace <PROFILE_UUID> below with the copied UUID
+# 4. Execute `dconf load /org/gnome/terminal/legacy/profiles:/ < ${_name}.dconf`
+
+[:<PROFILE_UUID>]
+background-color='${bg}'
+cursor-background-color='${fg}'
+cursor-colors-set=true
+cursor-foreground-color='${bg}'
+foreground-color='${fg}'
+highlight-background-color='${fg}'
+highlight-colors-set=true
+highlight-foreground-color='${bg}'
+palette=['${terminal_black}', '${red}', '${green}', '${yellow}', '${blue}', '${magenta}', '${cyan}', '${fg}', '${terminal_black}', '${red}', '${green}', '${yellow}', '${blue}', '${magenta}', '${cyan}', '${fg}']
+use-theme-colors=false
+visible-name='${_style_name}'
+]],
+        gnome_colors
+    )
+    return gnome_terminal
+end
+
+return M

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -14,6 +14,7 @@ M.extras = {
   foot             = { ext = "ini", url = "https://codeberg.org/dnkl/foot", label = "Foot" },
   fzf              = { ext = "sh", url = "https://github.com/junegunn/fzf", label = "Fzf" },
   gitui            = { ext = "ron", url = "https://github.com/extrawurst/gitui", label = "GitUI" },
+  gnome_terminal   = { ext = "dconf", url = "https://gitlab.gnome.org/GNOME/gnome-terminal", label = "GNOME Terminal"},
   helix            = { ext = "toml", url = "https://helix-editor.com/", label = "Helix" },
   iterm            = { ext = "itermcolors", url = "https://iterm2.com/", label = "iTerm" },
   kitty            = { ext = "conf", url = "https://sw.kovidgoyal.net/kitty/conf.html", label = "Kitty" },


### PR DESCRIPTION
This MR adds Tokyo Night themes for the GNOME terminal. An instruction on how to easily import the generated themes is included in the files itself.

I tested creating and importing every theme on my machine, which worked fine. Let me know if there's anything I can improve.