### PR TITLE
fix(day)!: Chose palette for day

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ require("tokyonight").setup({
     floats = "dark", -- style for floating windows
   },
   sidebars = { "qf", "help" }, -- Set a darker background on sidebar-like windows. For example: `["qf", "vista_kind", "terminal", "packer"]`
-  day_brightness = 0.3, -- Adjusts the brightness of the colors of the **Day** style. Number between 0 and 1, from dull to vibrant colors
   hide_inactive_statusline = false, -- Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**.
   dim_inactive = false, -- dims inactive windows
   lualine_bold = false, -- When `true`, section headers in the lualine theme will be bold

--- a/doc/tokyonight.nvim.txt
+++ b/doc/tokyonight.nvim.txt
@@ -195,7 +195,6 @@ unless `setup` is explicitly called.
         floats = "dark", -- style for floating windows
       },
       sidebars = { "qf", "help" }, -- Set a darker background on sidebar-like windows. For example: `["qf", "vista_kind", "terminal", "packer"]`
-      day_brightness = 0.3, -- Adjusts the brightness of the colors of the **Day** style. Number between 0 and 1, from dull to vibrant colors
       hide_inactive_statusline = false, -- Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**.
       dim_inactive = false, -- dims inactive windows
       lualine_bold = false, -- When `true`, section headers in the lualine theme will be bold

--- a/lua/tokyonight/colors.lua
+++ b/lua/tokyonight/colors.lua
@@ -46,7 +46,45 @@ M.night = {
   bg = "#1a1b26",
   bg_dark = "#16161e",
 }
-M.day = M.night
+
+M.day = {
+  none = "NONE",
+  bg_dark = "#e1e1e9",
+  bg = "#ffffff", -- "#d9dae5"
+  bg_highlight = "#bdc2d6",
+  terminal_black = "#eff0f5", -- "#cdd0e0",
+  fg = "#000000", -- "#0a143f",
+  fg_dark = "#293156",
+  fg_gutter = "#c6cadc",
+  dark3 = "#545c7e",
+  comment = "#4f577d",
+  dark5 = "#5d648c",
+  blue0 = "#c9d3ed",
+  blue = "#083085",
+  cyan = "#0071b3",
+  blue1 = "#1b96ac",
+  blue2 = "#0a91a8",
+  blue5 = "#0098d6",
+  blue6 = "#0c9c9a",
+  blue7 = "#b1bdd7",
+  magenta = "#7d3df0",
+  magenta2 = "#ff007c",
+  purple = "#6135b1",
+  orange = "#cc4c00",
+  yellow = "#ad8200",
+  green = "#349900",
+  green1 = "#27956a",
+  green2 = "#32804d",
+  teal = "#14947b",
+  red = "#e20d35",
+  red1 = "#bf2626",
+  git = { change = "#6183bb", add = "#449dab", delete = "#914c54" },
+  gitSigns = {
+    add = "#266d6a",
+    change = "#536c9e",
+    delete = "#b2555b",
+  },
+}
 
 M.moon = function()
   local ret = {
@@ -111,7 +149,6 @@ function M.setup(opts)
   local colors = vim.tbl_deep_extend("force", vim.deepcopy(M.default), palette)
 
   util.bg = colors.bg
-  util.day_brightness = config.options.day_brightness
 
   colors.diff = {
     add = util.darken(colors.green2, 0.15),
@@ -156,9 +193,6 @@ function M.setup(opts)
   }
 
   config.options.on_colors(colors)
-  if opts.transform and config.is_day() then
-    util.invert_colors(colors)
-  end
 
   return colors
 end

--- a/lua/tokyonight/config.lua
+++ b/lua/tokyonight/config.lua
@@ -20,7 +20,6 @@ local defaults = {
     floats = "dark", -- style for floating windows
   },
   sidebars = { "qf", "help" }, -- Set a darker background on sidebar-like windows. For example: `["qf", "vista_kind", "terminal", "packer"]`
-  day_brightness = 0.3, -- Adjusts the brightness of the colors of the **Day** style. Number between 0 and 1, from dull to vibrant colors
   hide_inactive_statusline = false, -- Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**.
   dim_inactive = false, -- dims inactive windows
   lualine_bold = false, -- When `true`, section headers in the lualine theme will be bold

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -885,11 +885,6 @@ function M.setup()
 
   options.on_highlights(theme.highlights, theme.colors)
 
-  if config.is_day() then
-    util.invert_colors(theme.colors)
-    util.invert_highlights(theme.highlights)
-  end
-
   return theme
 end
 

--- a/lua/tokyonight/util.lua
+++ b/lua/tokyonight/util.lua
@@ -2,7 +2,6 @@ local M = {}
 
 M.bg = "#000000"
 M.fg = "#ffffff"
-M.day_brightness = 0.3
 
 ---@param c  string
 local function hexToRgb(c)
@@ -39,9 +38,6 @@ function M.invert_color(color)
   if color ~= "NONE" then
     local hsl = hsluv.hex_to_hsluv(color)
     hsl[3] = 100 - hsl[3]
-    if hsl[3] < 40 then
-      hsl[3] = hsl[3] + (100 - hsl[3]) * M.day_brightness
-    end
     return hsluv.hsluv_to_hex(hsl)
   end
   return color


### PR DESCRIPTION
Thanks for creating this color scheme. I recently started using treesitter and found this colorscheme very helpful.

I did, however, find the day colors washed out. I like having a bright background (#ffffff) during the day; to do this I have to set `day_brightness = 0`, and in that case the colors are all washed out and too similar. Looking at the code, it looks like in day mode you just invert colors of the night palette and then increase the lightness if it is too dark. I couldn't find a clean elegant way to fix it so that foreground colors stay dark but are more vibrant.

Instead, I just manually inverted the colors and played with the saturation / lightness so that it was vibrant enough. With a manually chosen palette the `day_brightness` setting isn't needed anymore, so I removed it. (Technically the `invert_colors` and `invert_highlights` functions aren't needed either.)

Feel free to merge this if you like it.

Personally I use

    fg=#000000
    terminal_black=#000000
    bg=#ffffff

but I let the defaults be softer colors obtained by inverting the night palette.