### PR TITLE
Fix GitUi Themes to work with latest version

### DIFF
--- a/lua/tokyonight/extra/gitui.lua
+++ b/lua/tokyonight/extra/gitui.lua
@@ -7,7 +7,7 @@ local function hex2rgb(key, value)
   local g = tonumber(hex:sub(3, 4), 16)
   local b = tonumber(hex:sub(5, 6), 16)
 
-  return string.format("Rgb(%s,%s,%s), // %s %s", r, g, b, key, value)
+  return string.format("Some(Rgb(%s,%s,%s)), // %s %s", r, g, b, key, value)
 end
 
 local M = {}


### PR DESCRIPTION
https://github.com/extrawurst/gitui/blob/188d00159bdbdeaed57b283aa1bbfc84d60b23d1/THEMES.md?plain=1#L26

> Note that you need to wrap values in `Some` due to the way the overrides work (as of 0.23).