### PR TITLE
feat(extras) Added zellij colors

### DIFF
--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -26,6 +26,7 @@ M.extras = {
   gitui = {ext = "ron", url = "https://github.com/extrawurst/gitui", label = "GitUI"},
   helix = { ext = "toml", url = "https://helix-editor.com/", label = "Helix"},
   fzf = { ext = "zsh", url = "https://github.com/junegunn/fzf", label = "Fzf"},
+  zellij = {ext = "kdl", url = "https://zellij.dev/", label = "Zellij"},
 }
 
 local function write(str, fileName)

--- a/lua/tokyonight/extra/zellij.lua
+++ b/lua/tokyonight/extra/zellij.lua
@@ -1,0 +1,36 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @param colors ColorScheme
+function M.generate(colors)
+  local zellij = util.template(
+    [=[
+// Tokyonight Zellij Colors
+// Add this file to your `CONFIG_DIR/themes` directory as described here:
+// https://zellij.dev/documentation/themes#getting-zellij-to-pick-up-the-theme
+
+themes {
+    ${_name} {
+        fg "${fg}"
+        bg "${bg}"
+        black "${black}"
+        red "${red}"
+        green "${green}"
+        yellow "${yellow}"
+        blue "${blue}"
+        magenta "${magenta}"
+        cyan "${cyan}"
+        white "${fg_dark}"
+        orange "${orange}"
+    }
+}
+
+]=],
+    colors
+  )
+
+  return zellij
+end
+
+return M


### PR DESCRIPTION
This PR generates themes for [zellij](https://github.com/zellij-org/zellij) - A terminal workspace with batteries included.

They already ship with a version of tokyonight, but it is **not** auto-generated.
The original contributor stated that this was hacked together from his own config [here](https://github.com/zellij-org/zellij/pull/1015).

If the option for auto-generation is a valuable enough contribution to justify supporting/adding it nonetheless - feel free to pull.