### PR TITLE
helix: fix some broken generated values

### DIFF
--- a/lua/tokyonight/extra/helix.lua
+++ b/lua/tokyonight/extra/helix.lua
@@ -87,7 +87,7 @@ function M.generate(colors)
     ["function"] = {
       "Function",
       builtin = "@function.builtin",
-      method = "@method",
+      method = "@function.method",
       macro = "@function.macro",
       -- Defined as "preprocessor in C", so using "PreProc", not sure though
       special = "PreProc",
@@ -97,12 +97,12 @@ function M.generate(colors)
       -- ???
       builtin = nil,
     },
-    namespace = "@namespace",
+    namespace = "@lsp.type.namespace",
     special = "Special",
     markup = {
       nil,
       heading = {
-        "@text.title",
+        "@markup.heading",
         marker = nil,
         -- post-processed to remove the 'h' as we already use the first element (1) as the root value.
         h1 = nil,


### PR DESCRIPTION
the helix config currently has a [few](https://github.com/folke/tokyonight.nvim/blob/67afeaf7fd6ebba000633e89f63c31694057edde/extras/helix/tokyonight_night.toml#L25) [broken](https://github.com/folke/tokyonight.nvim/blob/67afeaf7fd6ebba000633e89f63c31694057edde/extras/helix/tokyonight_night.toml#L40) [lines](https://github.com/folke/tokyonight.nvim/blob/67afeaf7fd6ebba000633e89f63c31694057edde/extras/helix/tokyonight_night.toml#L55) that get generated in each of the variants due to some missing highlight tags.

i've updated the few broken queries to generate correct configs