### PR TITLE
xfceterm: colorscheme name fix

### DIFF
--- a/extras/xfceterm/tokyonight_day.theme
+++ b/extras/xfceterm/tokyonight_day.theme
@@ -1,5 +1,5 @@
 [Scheme]
-Name=TokyoNight Colors
+Name=tokyonight_day
 ColorBackground=#e1e2e7
 ColorForeground=#3760bf
 

--- a/extras/xfceterm/tokyonight_moon.theme
+++ b/extras/xfceterm/tokyonight_moon.theme
@@ -1,5 +1,5 @@
 [Scheme]
-Name=TokyoNight Colors
+Name=tokyonight_moon
 ColorBackground=#222436
 ColorForeground=#c8d3f5
 

--- a/extras/xfceterm/tokyonight_night.theme
+++ b/extras/xfceterm/tokyonight_night.theme
@@ -1,5 +1,5 @@
 [Scheme]
-Name=TokyoNight Colors
+Name=tokyonight_night
 ColorBackground=#1a1b26
 ColorForeground=#c0caf5
 

--- a/extras/xfceterm/tokyonight_storm.theme
+++ b/extras/xfceterm/tokyonight_storm.theme
@@ -1,5 +1,5 @@
 [Scheme]
-Name=TokyoNight Colors
+Name=tokyonight_storm
 ColorBackground=#24283b
 ColorForeground=#c0caf5
 

--- a/lua/tokyonight/extra/xfceterm.lua
+++ b/lua/tokyonight/extra/xfceterm.lua
@@ -7,7 +7,7 @@ function M.generate(colors)
   local xfceterm = util.template(
     [[
 [Scheme]
-Name=TokyoNight Colors
+Name="${_name}"
 ColorBackground=${bg}
 ColorForeground=${fg}
 


### PR DESCRIPTION
A simple change to be able to distinguish between the different color schemes in the XFCE terminal case.