### PR TITLE
fix(extras): zellij invisible selecting text

### DIFF
--- a/lua/tokyonight/extra/zellij.lua
+++ b/lua/tokyonight/extra/zellij.lua
@@ -13,7 +13,7 @@ function M.generate(colors)
 themes {
     ${_name} {
         fg "${fg}"
-        bg "${bg}"
+        bg "${bg_highlight}"
         black "${black}"
         red "${red}"
         green "${green}"


### PR DESCRIPTION
This closes #522.

"bg" for zellij is actually for the selected text background, not for the background color of whole ui of zellij. 

Before:
![Screenshot from 2024-05-31 18-47-26](https://github.com/folke/tokyonight.nvim/assets/93110982/7d3269cc-8bcd-407e-aea7-59582b655bce)

After:
![Screenshot from 2024-05-31 18-49-52](https://github.com/folke/tokyonight.nvim/assets/93110982/3d0ecaf1-e7e7-41ae-9b8d-7cd6bbf71408)