### PR TITLE
fix: mini.statusline colors, cursorcolumn and signcolumn linking with cursorline and cursorlinenr 

### DIFF
--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -48,8 +48,9 @@ function M.setup()
     VertSplit = { fg = c.border }, -- the column separating vertically split windows
     WinSeparator = { fg = c.border, bold = true }, -- the column separating vertically split windows
     Folded = { fg = c.blue, bg = c.fg_gutter }, -- line used for closed folds
-    FoldColumn = { bg = options.transparent and c.none or c.bg, fg = c.comment }, -- 'foldcolumn'
-    SignColumn = { bg = options.transparent and c.none or c.bg, fg = c.fg_gutter }, -- column where |signs| are displayed
+    FoldColumn = { link = "LineNr" }, -- 'foldcolumn'
+    CursorLineFold = { link = "CursorLineNr" }, -- Like FoldColumn but when curosrline is on the fold column.
+    SignColumn = { link = "LineNr" }, -- column where |signs| are displayed
     SignColumnSB = { bg = c.bg_sidebar, fg = c.fg_gutter }, -- column where |signs| are displayed
     Substitute = { bg = c.red, fg = c.black }, -- |:substitute| replacement text highlighting
     LineNr = { fg = c.fg_gutter }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
@@ -791,9 +792,9 @@ function M.setup()
     MiniStarterSection = { fg = c.blue1 },
     MiniStarterQuery = { fg = c.info },
 
-    MiniStatuslineDevinfo = { fg = c.fg_dark, bg = c.bg_highlight },
-    MiniStatuslineFileinfo = { fg = c.fg_dark, bg = c.bg_highlight },
-    MiniStatuslineFilename = { fg = c.fg_dark, bg = c.fg_gutter },
+    MiniStatuslineDevinfo = { fg = c.fg_dark, bg = c.fg_gutter },
+    MiniStatuslineFileinfo = { fg = c.fg_dark, bg = c.fg_gutter },
+    MiniStatuslineFilename = { fg = c.fg_dark, bg = c.bg_highlight },
     MiniStatuslineInactive = { fg = c.blue, bg = c.bg_statusline },
     MiniStatuslineModeCommand = { fg = c.black, bg = c.yellow, bold = true },
     MiniStatuslineModeInsert = { fg = c.black, bg = c.green, bold = true },

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -49,8 +49,9 @@ function M.setup()
     WinSeparator = { fg = c.border, bold = true }, -- the column separating vertically split windows
     Folded = { fg = c.blue, bg = c.fg_gutter }, -- line used for closed folds
     FoldColumn = { link = "LineNr" }, -- 'foldcolumn'
-    CursorLineFold = { link = "CursorLineNr" }, -- Like FoldColumn but when curosrline is on the fold column.
     SignColumn = { link = "LineNr" }, -- column where |signs| are displayed
+    CursorLineFold = { link = "CursorLineNr" }, -- Like FoldColumn but when curosrline is on the fold column.
+    CursorLineSign = { link = "CursorLineNr" }, -- Like SignColumn but when curosrline is on the sign column.
     SignColumnSB = { bg = c.bg_sidebar, fg = c.fg_gutter }, -- column where |signs| are displayed
     Substitute = { bg = c.red, fg = c.black }, -- |:substitute| replacement text highlighting
     LineNr = { fg = c.fg_gutter }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.


### PR DESCRIPTION
Changes for ministatusline and linking cursorcolumn and signcolumn to LineNr
```lua
on_highlights = function(highlights, colors)
        -- Ministatusline changes
        highlights.MiniStatuslineDevinfo = { fg = colors.fg_dark, bg = colors.fg_gutter }
	highlights.MiniStatuslineFileinfo = { fg = colors.fg_dark, bg = colors.fg_gutter }
	highlights.MiniStatuslineFilename = { fg = colors.fg_dark, bg = colors.bg_highlight }
        -- cursorcolumn and signcolumn linking to lineNr
	highlights.SignColumn = { link = "LineNr" }
	highlights.FoldColumn = { link = "LineNr" }
        highlights.CursorLineFold = { link = "CursorLineNr" }
        highlights.CursorLineSign = { link = "CursorLineNr" }
end
```

## MiniStatusline
Without the Ministatusline changes the statusline looks something like this
![image](https://github.com/folke/tokyonight.nvim/assets/56352048/5200b51a-253d-42c9-ba71-4691c5e5fb68)
With the changes of Ministatusline it looks something like this
![image](https://github.com/folke/tokyonight.nvim/assets/56352048/267ec02e-9f73-4213-9ca2-d6165abee5cf)

## SignColumn and FoldColumn changes
Without the signcolumn and foldcolumn changes the column looks something like this
![image](https://github.com/folke/tokyonight.nvim/assets/56352048/38f9e112-61f0-49c2-a53d-e4485e3e93c2)
With the signcolumn and foldcolumn changes the column looks something like this
![image](https://github.com/folke/tokyonight.nvim/assets/56352048/d3b832d0-a725-4980-9d4e-ad3b01854b19)
