### PR TITLE
fix: typo sim_inactive should be dim_inactive

### DIFF
--- a/lua/tokyonight/groups/init.lua
+++ b/lua/tokyonight/groups/init.lua
@@ -132,7 +132,7 @@ function M.load(colors, opts)
     colors = colors,
     plugins = names,
     version = Config.version,
-    opts = { styles = opts.styles, sim_inactive = opts.dim_inactive },
+    opts = { styles = opts.styles, dim_inactive = opts.dim_inactive },
   }
 
   local ret = cache and vim.deep_equal(inputs, cache.inputs) and cache.groups


### PR DESCRIPTION
This PR corrects a typo in groups - init.lua

I also noticed in news.md:

```md
By default `opts.plugins.all = true` for users not using `lazy.nvim`, which will enable all plugins.
```

Perhaps:

```md
By default `opts.plugins.all = true` for users not using `lazy.nvim` will enable all plugins.
```

And: 

```md
It mostly configures [mini.hipatterns](https://github.com/echasnovski/mini.hipatterns) to easily
what the colors and highlight groups look like.
```

Perhaps:
```md
It mostly configures [mini.hipatterns](https://github.com/echasnovski/mini.hipatterns) to easily see
what the colors and highlight groups look like.
```



