### PR TITLE
fix: reverse colors of devinfo and fileinfo with filename to make the colors look like lualine for mini.statusline

### DIFF
--- a/lua/tokyonight/groups/mini_statusline.lua
+++ b/lua/tokyonight/groups/mini_statusline.lua
@@ -4,9 +4,9 @@ local M = {}
 function M.get(c)
   -- stylua: ignore
   return {
-    MiniStatuslineDevinfo     = { fg = c.fg_dark, bg = c.bg_highlight },
-    MiniStatuslineFileinfo    = { fg = c.fg_dark, bg = c.bg_highlight },
-    MiniStatuslineFilename    = { fg = c.fg_dark, bg = c.fg_gutter },
+    MiniStatuslineDevinfo     = { fg = c.fg_dark, bg = c.fg_gutter },
+    MiniStatuslineFileinfo    = { fg = c.fg_dark, bg = c.fg_gutter },
+    MiniStatuslineFilename    = { fg = c.fg_dark, bg = c.bg_highlight },
     MiniStatuslineInactive    = { fg = c.blue, bg = c.bg_statusline },
     MiniStatuslineModeCommand = { fg = c.black, bg = c.yellow, bold = true },
     MiniStatuslineModeInsert  = { fg = c.black, bg = c.green, bold = true },


### PR DESCRIPTION
This is a PR to address https://github.com/folke/tokyonight.nvim/issues/557
Without the changes made.
![image](https://github.com/folke/tokyonight.nvim/assets/56352048/f78ecaaa-fd83-4411-8725-3e8f762128da)
With the changes made.
![image](https://github.com/folke/tokyonight.nvim/assets/56352048/195d42ed-d7d0-4ab7-a275-887baf893209)
