### PR TITLE
Add hl group for indentmini plugin

### DIFF
--- a/lua/tokyonight/groups/indent-blankline.lua
+++ b/lua/tokyonight/groups/indent-blankline.lua
@@ -10,8 +10,6 @@ function M.get(c, opts)
     IndentBlanklineContextChar = { fg = c.blue1, nocombine = true },
     IblIndent                  = { fg = c.fg_gutter, nocombine = true },
     IblScope                   = { fg = c.blue1, nocombine = true },
-    IndentLine                 = { fg = c.fg_gutter, nocombine = true },
-    IndentLineCurrent          = { fg = c.blue1, nocombine = true },
   }
 end
 

--- a/lua/tokyonight/groups/indentmini.lua
+++ b/lua/tokyonight/groups/indentmini.lua
@@ -1,0 +1,14 @@
+local M = {}
+
+M.url = "https://github.com/nvimdev/indentmini.nvim"
+
+---@type tokyonight.HighlightsFn
+function M.get(c, opts)
+  -- stylua: ignore
+  return {
+    IndentLine                 = { fg = c.fg_gutter, nocombine = true },
+    IndentLineCurrent          = { fg = c.blue1, nocombine = true },
+  }
+end
+
+return M

--- a/lua/tokyonight/groups/init.lua
+++ b/lua/tokyonight/groups/init.lua
@@ -17,6 +17,7 @@ M.plugins = {
   ["headlines.nvim"]                = "headlines",
   ["hop.nvim"]                      = "hop",
   ["indent-blankline.nvim"]         = "indent-blankline",
+  ["indentmini.nvim"]               = "indentmini",
   ["lazy.nvim"]                     = "lazy",
   ["leap.nvim"]                     = "leap",
   ["lspsaga.nvim"]                  = "lspsaga",


### PR DESCRIPTION
Adds support for [indentmini](https://github.com/nvimdev/indentmini.nvim) hightlight groups.

`IndentLine` and `IndentLineCurrent` highlight groups are not really used by [indent-blankline](https://github.com/lukas-reineke/indent-blankline.nvim) plugin.

These were added with [3c19449](https://github.com/folke/tokyonight.nvim/commit/3c194496dd5b640e1aefd9492c34d04ddbb1f136), but they were left in `indent-blankline`'s group after `v4`.

This PR moves them to a separate file, which will be automatically loaded for lazy.nvim users, if they have the plugin installed.

Cheers!