### PR TITLE
fix(vimwiki): `VimwikiHeader` highlights and URL metadata

### DIFF
--- a/lua/tokyonight/groups/vimwiki.lua
+++ b/lua/tokyonight/groups/vimwiki.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-M.url = "https://github.com/lukas-reineke/headlines.nvim"
+M.url = "https://github.com/vimwiki/vimwiki"
 
 ---@type tokyonight.HighlightsFn
 function M.get(c, opts)
@@ -14,7 +14,7 @@ function M.get(c, opts)
     VimwikiMarkers = { fg = c.blue, bg = c.none },
   }
   for i, color in ipairs(c.rainbow) do
-    ret["VimwikiHeaer" .. i] = { fg = color, bg = c.none, bold = true }
+    ret["VimwikiHeader" .. i] = { fg = color, bg = c.none, bold = true }
   end
   return ret
 end


### PR DESCRIPTION
## What is this PR for?
Vimwiki support was added in [8850021bed1d8595581a5903fd03acacf0d12af5](https://github.com/folke/tokyonight.nvim/commit/8850021bed1d8595581a5903fd03acacf0d12af5) but there was a typo in the generation of the `VimwikiHeader` highlights and instead they were generated under `VimwikiHeaer`. It also seems the the URL was set to headlines.nvim by mistake, presumably because this file was based off of the headlines.nvim group file.

Disclaimer: I don't actually use vimwiki but I was looking through the commits and saw this easy to fix bug so I did it myself.