### PR TITLE
fix(leap): use `LeapLabel`

### DIFF
--- a/lua/tokyonight/groups/leap.lua
+++ b/lua/tokyonight/groups/leap.lua
@@ -7,8 +7,7 @@ function M.get(c, opts)
   -- stylua: ignore
   return {
     LeapMatch          = { bg = c.magenta2, fg = c.fg, bold = true },
-    LeapLabelPrimary   = { fg = c.magenta2, bold = true },
-    LeapLabelSecondary = { fg = c.green1, bold = true },
+    LeapLabel          = { fg = c.magenta2, bold = true },
     LeapBackdrop       = { fg = c.dark3 },
   }
 end


### PR DESCRIPTION
`LeapLabelPrimary`, `LeapLabelSecondary` deprecated ([b75a86f](https://github.com/ggandor/leap.nvim/commit/b75a86f14ebdb3940460bfd1a02224210eccc698))

## What is this PR for?

Brings back leap labels highlight

## Does this PR fix an existing issue?
- Fixes #578 