### PR TITLE
fix(leap): use `LeapLabel`

### DIFF
--- a/extras/lua/tokyonight_day.lua
+++ b/extras/lua/tokyonight_day.lua
@@ -969,13 +969,9 @@ local highlights = {
   LeapBackdrop = {
     fg = "#8990b3"
   },
-  LeapLabelPrimary = {
+  LeapLabel = {
     bold = true,
     fg = "#d20065"
-  },
-  LeapLabelSecondary = {
-    bold = true,
-    fg = "#387068"
   },
   LeapMatch = {
     bg = "#d20065",

--- a/extras/lua/tokyonight_moon.lua
+++ b/extras/lua/tokyonight_moon.lua
@@ -969,13 +969,9 @@ local highlights = {
   LeapBackdrop = {
     fg = "#545c7e"
   },
-  LeapLabelPrimary = {
+  LeapLabel = {
     bold = true,
     fg = "#ff007c"
-  },
-  LeapLabelSecondary = {
-    bold = true,
-    fg = "#4fd6be"
   },
   LeapMatch = {
     bg = "#ff007c",

--- a/extras/lua/tokyonight_night.lua
+++ b/extras/lua/tokyonight_night.lua
@@ -969,13 +969,9 @@ local highlights = {
   LeapBackdrop = {
     fg = "#545c7e"
   },
-  LeapLabelPrimary = {
+  LeapLabel = {
     bold = true,
     fg = "#ff007c"
-  },
-  LeapLabelSecondary = {
-    bold = true,
-    fg = "#73daca"
   },
   LeapMatch = {
     bg = "#ff007c",

--- a/extras/lua/tokyonight_storm.lua
+++ b/extras/lua/tokyonight_storm.lua
@@ -969,13 +969,9 @@ local highlights = {
   LeapBackdrop = {
     fg = "#545c7e"
   },
-  LeapLabelPrimary = {
+  LeapLabel = {
     bold = true,
     fg = "#ff007c"
-  },
-  LeapLabelSecondary = {
-    bold = true,
-    fg = "#73daca"
   },
   LeapMatch = {
     bg = "#ff007c",

--- a/lua/tokyonight/groups/leap.lua
+++ b/lua/tokyonight/groups/leap.lua
@@ -7,8 +7,7 @@ function M.get(c, opts)
   -- stylua: ignore
   return {
     LeapMatch          = { bg = c.magenta2, fg = c.fg, bold = true },
-    LeapLabelPrimary   = { fg = c.magenta2, bold = true },
-    LeapLabelSecondary = { fg = c.green1, bold = true },
+    LeapLabel          = { fg = c.magenta2, bold = true },
     LeapBackdrop       = { fg = c.dark3 },
   }
 end


### PR DESCRIPTION
`LeapLabelPrimary`, `LeapLabelSecondary` deprecated ([b75a86f](https://github.com/ggandor/leap.nvim/commit/b75a86f14ebdb3940460bfd1a02224210eccc698))

- Also updated extras colors

## What is this PR for?

Brings back leap labels highlight

## Does this PR fix an existing issue?
- Fixes #578 