### PR TITLE
feat(dashboard): add dashboard hyper theme

### DIFF
--- a/lua/tokyonight/groups/dashboard.lua
+++ b/lua/tokyonight/groups/dashboard.lua
@@ -1,18 +1,27 @@
 local M = {}
 
-M.url = "https://github.com/glepnir/dashboard-nvim"
+M.url = "https://github.com/nvimdev/dashboard-nvim"
 
 ---@type tokyonight.HighlightsFn
 function M.get(c, opts)
   -- stylua: ignore
   return {
-    DashboardShortCut = { fg = c.cyan },
+    -- General
     DashboardHeader   = { fg = c.blue },
-    DashboardCenter   = { fg = c.magenta },
     DashboardFooter   = { fg = c.blue1 },
-    DashboardKey      = { fg = c.orange },
+    -- Hyper theme
+    Dashboardprojecttitle = { fg = c.cyan }
+    Dashboardprojecttitleicon = { fg = c.orange }
+    Dashboardprojecticon = { fg = c.yellow }
+    Dashboardmrutitle = { fg = c.cyan }
+    Dashboardmruicon = { fg = c.purple }
+    Dashboardfiles = { fg = c.blue }
+    Dashboardshortcuticon = { fg = c.magenta }
+    -- Doome theme
     DashboardDesc     = { fg = c.cyan },
+    DashboardKey      = { fg = c.orange },
     DashboardIcon     = { fg = c.cyan, bold = true },
+    DashboardShortCut = { fg = c.cyan },
   }
 end
 

--- a/lua/tokyonight/groups/dashboard.lua
+++ b/lua/tokyonight/groups/dashboard.lua
@@ -11,12 +11,12 @@ function M.get(c, opts)
     DashboardFooter           = { fg = c.blue1 },
     -- Hyper theme
     DashboardProjectTitle     = { fg = c.cyan },
-    DashboardProjectTitleIcon = { fg = c.red },
+    DashboardProjectTitleIcon = { fg = c.orange },
     DashboardProjectIcon      = { fg = c.yellow },
     DashboardMruTitle         = { fg = c.cyan },
     DashboardMruIcon          = { fg = c.purple },
     DashboardFiles            = { fg = c.blue },
-    DashboardShortcutIcon     = { fg = c.magenta },
+    DashboardShortCutIcon     = { fg = c.magenta },
     -- Doome theme
     DashboardDesc             = { fg = c.cyan },
     DashboardKey              = { fg = c.orange },

--- a/lua/tokyonight/groups/dashboard.lua
+++ b/lua/tokyonight/groups/dashboard.lua
@@ -7,21 +7,21 @@ function M.get(c, opts)
   -- stylua: ignore
   return {
     -- General
-    DashboardHeader   = { fg = c.blue },
-    DashboardFooter   = { fg = c.blue1 },
+    DashboardHeader           = { fg = c.blue },
+    DashboardFooter           = { fg = c.blue1 },
     -- Hyper theme
-    Dashboardprojecttitle = { fg = c.cyan }
-    Dashboardprojecttitleicon = { fg = c.orange }
-    Dashboardprojecticon = { fg = c.yellow }
-    Dashboardmrutitle = { fg = c.cyan }
-    Dashboardmruicon = { fg = c.purple }
-    Dashboardfiles = { fg = c.blue }
-    Dashboardshortcuticon = { fg = c.magenta }
+    DashboardProjectTitle     = { fg = c.cyan },
+    DashboardProjectTitleIcon = { fg = c.red },
+    DashboardProjectIcon      = { fg = c.yellow },
+    DashboardMruTitle         = { fg = c.cyan },
+    DashboardMruIcon          = { fg = c.purple },
+    DashboardFiles            = { fg = c.blue },
+    DashboardShortcutIcon     = { fg = c.magenta },
     -- Doome theme
-    DashboardDesc     = { fg = c.cyan },
-    DashboardKey      = { fg = c.orange },
-    DashboardIcon     = { fg = c.cyan, bold = true },
-    DashboardShortCut = { fg = c.cyan },
+    DashboardDesc             = { fg = c.cyan },
+    DashboardKey              = { fg = c.orange },
+    DashboardIcon             = { fg = c.cyan, bold = true },
+    DashboardShortCut         = { fg = c.cyan },
   }
 end
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Currently the dashboard theme is only applied to `Doome` but `Hyper` is missing.
## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

