### PR TITLE
feat(zellij): make top and bottom bars transparent

### DIFF
--- a/lua/tokyonight/extra/zellij.lua
+++ b/lua/tokyonight/extra/zellij.lua
@@ -14,7 +14,9 @@ themes {
     ${_name} {
         fg "${fg}"
         bg "${bg_highlight}"
-        black "${black}"
+        // Black should match the terminal background color
+        // This ensures the top and bottom bars are transparent
+        black "${bg}"
         red "${red}"
         green "${green}"
         yellow "${yellow}"


### PR DESCRIPTION
## Description

This PR expects a user to use the Tokyonight theme for the running Terminal too.
The black color in Zellij should match the Teriminal background color,
This ensures the top and bottom bars are transparent

## Related Issue(s)

No

## Screenshots

- Before
![image](https://github.com/folke/tokyonight.nvim/assets/17734314/70105867-7d19-47da-b2fe-f78a5374e6d5)

- After
![image](https://github.com/folke/tokyonight.nvim/assets/17734314/24aa2c78-89ec-4544-be93-3d6fa04decea)


