### PR TITLE
style(treesitter): add treesitter tag.builtin keyword

### DIFF
--- a/lua/tokyonight/groups/treesitter.lua
+++ b/lua/tokyonight/groups/treesitter.lua
@@ -84,6 +84,7 @@ function M.get(c, opts)
     ["@string.regexp"]              = { fg = c.blue6 }, -- For regexes.
     ["@tag"]                        = "Label",
     ["@tag.attribute"]              = "@property",
+    ["@tag.builtin"]                = "Label", -- XML-style tag names (e.g. HTML5 tags)
     ["@tag.delimiter"]              = "Delimiter",
     ["@tag.delimiter.tsx"]          = { fg = Util.blend_bg(c.blue, 0.7) },
     ["@tag.tsx"]                    = { fg = c.red },


### PR DESCRIPTION
## Description
This PR adds keyword to treesitter for html tag names support and will make html tags use their default colors when using javascript frameworks like reactjs.


## Screenshots
Without ["@tag.builtin"], the html tags inside reactjs uses different colors compared to colors inside vanila html files.
![2024-07-13_12-28](https://github.com/user-attachments/assets/767a5767-5343-44f9-b7cf-32ef3437f6f8)


With the added treesitter keyword ["@tag.builtin"].
![2024-07-13_12-30](https://github.com/user-attachments/assets/a526278a-09b4-4c08-97e0-6f7e048f45aa)


