### PR TITLE
feat(extras): add fuzzel theme

### DIFF
--- a/lua/tokyonight/extra/fuzzel.lua
+++ b/lua/tokyonight/extra/fuzzel.lua
@@ -1,0 +1,29 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @param colors ColorScheme
+function M.generate(colors)
+  local fuzzelColors = {}
+  for k, v in pairs(colors) do
+    if type(v) == "string" then
+      fuzzelColors[k] = v:gsub("^#", "") .. "ff"
+    end
+  end
+  local fuzzel = util.template(
+    [[
+[colors]
+background=${bg_popup}
+text=${fg}
+match=${blue1}
+selection=${bg_highlight}
+selection-match=${blue1}
+selection-text=${fg}
+border=${border_highlight}
+]],
+    fuzzelColors
+  )
+  return fuzzel
+end
+
+return M

--- a/lua/tokyonight/extra/fuzzel.lua
+++ b/lua/tokyonight/extra/fuzzel.lua
@@ -5,18 +5,20 @@ local M = {}
 --- @param colors ColorScheme
 function M.generate(colors)
   local fuzzelColors = {}
+  colors.bg_search = util.blend_bg(colors.fg_gutter, 0.8)
   for k, v in pairs(colors) do
     if type(v) == "string" then
       fuzzelColors[k] = v:gsub("^#", "") .. "ff"
     end
   end
+
   local fuzzel = util.template(
     [[
 [colors]
 background=${bg_popup}
 text=${fg}
 match=${blue1}
-selection=${bg_highlight}
+selection=${bg_search}
 selection-match=${blue1}
 selection-text=${fg}
 border=${border_highlight}

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -13,6 +13,7 @@ M.extras = {
   fish             = { ext = "fish", url = "https://fishshell.com/docs/current/index.html", label = "Fish" },
   fish_themes      = { ext = "theme", url = "https://fishshell.com/docs/current/interactive.html#syntax-highlighting", label = "Fish Themes" },
   foot             = { ext = "ini", url = "https://codeberg.org/dnkl/foot", label = "Foot" },
+  fuzzel           = { ext = "ini", url = "https://codeberg.org/dnkl/fuzzel", label = "Fuzzel" },
   fzf              = { ext = "sh", url = "https://github.com/junegunn/fzf", label = "Fzf" },
   gitui            = { ext = "ron", url = "https://github.com/extrawurst/gitui", label = "GitUI" },
   gnome_terminal   = { ext = "dconf", url = "https://gitlab.gnome.org/GNOME/gnome-terminal", label = "GNOME Terminal" },


### PR DESCRIPTION
## Description
This PR is extra theme for fuzzel, a application launcher.

I choose darker bg to make it obvious under the terminal with same theme which is displayed on screenshot.

Terminal & fuzzel theme: tokyonight moon
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
![Screenshot from 2024-07-22 00-52-42](https://github.com/user-attachments/assets/2457211f-08d5-4b41-883a-25d3ced24330)


