### PR TITLE
fix(mini_tabline): make MiniTablineTabpagesection more visible

### DIFF
--- a/lua/tokyonight/groups/mini_tabline.lua
+++ b/lua/tokyonight/groups/mini_tabline.lua
@@ -14,7 +14,7 @@ function M.get(c)
     MiniTablineModifiedCurrent = { fg = c.warning, bg = c.fg_gutter },
     MiniTablineModifiedHidden  = { bg = c.bg_statusline, fg = Util.blend_bg(c.warning, 0.7) },
     MiniTablineModifiedVisible = { fg = c.warning, bg = c.bg_statusline },
-    MiniTablineTabpagesection  = { bg = c.bg_statusline, fg = c.none },
+    MiniTablineTabpagesection  = { bg = c.fg_gutter, fg = c.none },
     MiniTablineVisible         = { fg = c.fg, bg = c.bg_statusline },
   }
 end


### PR DESCRIPTION
## Description
This PR makes MiniTablineTabpagesection more visible.
Before changes
![image](https://github.com/user-attachments/assets/3276ea59-0205-4c47-8b32-8f2cfd8d09f4)
After changes
![image](https://github.com/user-attachments/assets/fed71f26-c810-4f53-a744-6c3b4155eef2)


