### PR TITLE
fix(groups): changing the transparent option now correctly invalidates the cache

### DIFF
--- a/lua/tokyonight/groups/init.lua
+++ b/lua/tokyonight/groups/init.lua
@@ -137,7 +137,7 @@ function M.setup(colors, opts)
     colors = colors,
     plugins = names,
     version = Config.version,
-    opts = { styles = opts.styles, dim_inactive = opts.dim_inactive },
+    opts = { transparent = opts.transparent, styles = opts.styles, dim_inactive = opts.dim_inactive },
   }
 
   local ret = cache and vim.deep_equal(inputs, cache.inputs) and cache.groups


### PR DESCRIPTION
## Description
this PR fixes the issue where changing "transparent" option wasn't taken into account when cache was active due to cache not being invalidated properly for "transparent" value changes.

## Related Issue(s)


  - Fixes #561


