### PR TITLE
fix(which-key): delete duplicate WhichKeySeparator group

### DIFF
--- a/lua/tokyonight/groups/which-key.lua
+++ b/lua/tokyonight/groups/which-key.lua
@@ -9,7 +9,6 @@ function M.get(c, opts)
     WhichKey          = { fg = c.cyan },
     WhichKeyGroup     = { fg = c.blue },
     WhichKeyDesc      = { fg = c.magenta },
-    WhichKeySeperator = { fg = c.comment },
     WhichKeySeparator = { fg = c.comment },
     WhichKeyNormal     = { bg = c.bg_sidebar },
     WhichKeyValue     = { fg = c.dark5 },


### PR DESCRIPTION
## Description
Delete duplicate WhichKeySeparator highlight group.


