### PR TITLE
fix(terminal): assign magenta to correct terminal color

### DIFF
--- a/lua/tokyonight/groups/base.lua
+++ b/lua/tokyonight/groups/base.lua
@@ -46,7 +46,9 @@ function M.get(c, opts)
     FloatBorder                 = { fg = c.border_highlight, bg = c.bg_float },
     FloatTitle                  = { fg = c.border_highlight, bg = c.bg_float },
     Pmenu                       = { bg = c.bg_popup, fg = c.fg }, -- Popup menu: normal item.
+    PmenuMatch                  = { bg = c.bg_popup, fg = c.blue1 }, -- Popup menu: Matched text in normal item.
     PmenuSel                    = { bg = Util.blend_bg(c.fg_gutter, 0.8) }, -- Popup menu: selected item.
+    PmenuMatchSel               = { bg = Util.blend_bg(c.fg_gutter, 0.8), fg = c.blue1 }, -- Popup menu: Matched text in selected item.
     PmenuSbar                   = { bg = Util.blend_fg(c.bg_popup, 0.95) }, -- Popup menu: scrollbar.
     PmenuThumb                  = { bg = c.fg_gutter }, -- Popup menu: Thumb of the scrollbar.
     Question                    = { fg = c.blue }, -- |hit-enter| prompt and yes/no questions

--- a/lua/tokyonight/theme.lua
+++ b/lua/tokyonight/theme.lua
@@ -53,7 +53,7 @@ function M.terminal(colors)
   vim.g.terminal_color_12 = Util.blend_fg(colors.blue, 0.5)
 
   vim.g.terminal_color_5 = colors.magenta
-  vim.g.terminal_color_18 = Util.blend_fg(colors.magenta, 0.5)
+  vim.g.terminal_color_13 = Util.blend_fg(colors.magenta, 0.5)
 
   vim.g.terminal_color_6 = colors.cyan
   vim.g.terminal_color_14 = Util.blend_fg(colors.cyan, 0.5)


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

This PR addresses 2 things:
1. Fixes the terminal color typo mentioned in #634 
2. Adds `PmenuMatch` and `PmenuMatchSel` hl groups, see https://github.com/neovim/neovim/pull/29311

## Related Issue(s)
FIxes #634 
https://github.com/neovim/neovim/pull/29311
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

Here's before and after the `PmenuMatch` hl groups (Built in lsp completion):

Before:

![screenshot_2024_10_04_14_58_28](https://github.com/user-attachments/assets/7777c028-34d7-40e7-90b2-ee12cf881984)

After:
![screenshot_2024_10_04_14_57_56](https://github.com/user-attachments/assets/ce276677-4b5e-4e7a-b34a-55911d9203ff)



