### PR TITLE
feat(extras): add termux colors

### DIFF
--- a/extras/termux/README.md
+++ b/extras/termux/README.md
@@ -1,0 +1,7 @@
+## Tokyonight for [termux](https://termux.dev/)
+
+### Usage
+
+1. Choose your flavour.
+2. Copy the contents of `tokyonight_flavour.properties` to `~/.termux/colors.properties`.
+3. Then run `termux-reload-settings` or restart termux.

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -28,6 +28,7 @@ M.extras = {
   sublime          = { ext = "tmTheme", url = "https://www.sublimetext.com/docs/themes", label = "Sublime Text" },
   spotify_player   = { ext = "toml", url = "https://github.com/aome510/spotify-player", label = "Spotify Player" },
   terminator       = { ext = "conf", url = "https://gnome-terminator.readthedocs.io/en/latest/config.html", label = "Terminator" },
+  termux           = { ext = "properties", url = "https://termux.dev/", label = "Termux" },
   tilix            = { ext = "json", url = "https://github.com/gnunn1/tilix", label = "Tilix" },
   tmux             = { ext = "tmux", url = "https://github.com/tmux/tmux/wiki", label = "Tmux" },
   wezterm          = { ext = "toml", url = "https://wezfurlong.org/wezterm/config/files.html", label = "WezTerm" },

--- a/lua/tokyonight/extra/termux.lua
+++ b/lua/tokyonight/extra/termux.lua
@@ -1,0 +1,56 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @param colors ColorScheme
+function M.generate(colors)
+  local extended_colors = vim.tbl_extend("force", colors, {
+    red_bright = util.blend_fg(colors.red, 0.5),
+    green_bright = util.blend_fg(colors.green, 0.5),
+    yellow_bright = util.blend_fg(colors.yellow, 0.5),
+    blue_bright = util.blend_fg(colors.blue, 0.5),
+    magenta_bright = util.blend_fg(colors.magenta, 0.5),
+    cyan_bright = util.blend_fg(colors.cyan, 0.5),
+  })
+
+  local termux = util.template(
+    [[
+# -----------------------------------------------------------------------------
+# Theme: ${_style_name}
+# Upstream: ${_upstream_url}
+# -----------------------------------------------------------------------------
+
+background: ${bg}
+foreground: ${fg}
+
+# Normal colors
+color0:  ${black}
+color1:  ${red}
+color2:  ${green}
+color3:  ${yellow}
+color4:  ${blue}
+color5:  ${magenta}
+color6:  ${cyan}
+color7:  ${fg_dark}
+
+# Bright colors
+color8:  ${terminal_black}
+color9:  ${red_bright}
+color10: ${green_bright}
+color11: ${yellow_bright}
+color12: ${blue_bright}
+color13: ${magenta_bright}
+color14: ${cyan_bright}
+color15: ${fg}
+
+# Extended colors
+color16: ${orange}
+color17: ${red1}
+]],
+    extended_colors
+  )
+
+  return termux
+end
+
+return M


### PR DESCRIPTION
## Description

Add color config for [termux](https://termux.dev)

## Screenshots

![Screenshot_20241015-031413_Termux](https://github.com/user-attachments/assets/25f8f675-be36-49f4-8fe6-7fef65e69d60)
![Screenshot_20241015-021822_Termux](https://github.com/user-attachments/assets/c52472bf-a9ea-4996-ab13-e11f02d8dd03)
![Screenshot_20241015-021952_Termux](https://github.com/user-attachments/assets/3c27b83a-f03d-4430-ac12-44d1f1ba2287)
![Screenshot_20241015-021927_Termux](https://github.com/user-attachments/assets/f9eb43fe-f012-4973-8ff2-b2fe30a58a7a)


