### PR TITLE
doc: fix underscore colours guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ To have undercurls show up and in color, add the following to your
 # Undercurl
 set -g default-terminal "${TERM}"
 set -as terminal-overrides ',*:Smulx=\E[4::%p1%dm'  # undercurl support
-set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'  # underscore colours - needs tmux-3.0
+set -as terminal-overrides ',*:Setulc=\E[58::2::::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'  # underscore colours - needs tmux-3.0
 ```
 
 </details>


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

According to [this answer](https://askubuntu.com/a/985386), `\E58:2:R:G:Bm` is considered a "rarely used incorrect format" for truecolor.

I tested it on Windows Terminal with WSL2, and it didn’t work. After changing the format to `\E58::2:R:G:Bm`, which is noted as the "commonly used standard way," it worked as expected.

The change I made is as follows:

```diff
- set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'
+ set -as terminal-overrides ',*:Setulc=\E[58::2::::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'
```

I’d appreciate it if someone could test this on more platforms.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

