### PR TITLE
fix(termux): update termux theme to use the new terminal colors

### DIFF
--- a/lua/tokyonight/extra/termux.lua
+++ b/lua/tokyonight/extra/termux.lua
@@ -4,15 +4,6 @@ local M = {}
 
 --- @param colors ColorScheme
 function M.generate(colors)
-  local extended_colors = vim.tbl_extend("force", colors, {
-    red_bright = util.blend_fg(colors.red, 0.5),
-    green_bright = util.blend_fg(colors.green, 0.5),
-    yellow_bright = util.blend_fg(colors.yellow, 0.5),
-    blue_bright = util.blend_fg(colors.blue, 0.5),
-    magenta_bright = util.blend_fg(colors.magenta, 0.5),
-    cyan_bright = util.blend_fg(colors.cyan, 0.5),
-  })
-
   local termux = util.template(
     [[
 # -----------------------------------------------------------------------------
@@ -24,30 +15,30 @@ background: ${bg}
 foreground: ${fg}
 
 # Normal colors
-color0:  ${black}
-color1:  ${red}
-color2:  ${green}
-color3:  ${yellow}
-color4:  ${blue}
-color5:  ${magenta}
-color6:  ${cyan}
-color7:  ${fg_dark}
+color0:  ${terminal.black}
+color1:  ${terminal.red}
+color2:  ${terminal.green}
+color3:  ${terminal.yellow}
+color4:  ${terminal.blue}
+color5:  ${terminal.magenta}
+color6:  ${terminal.cyan}
+color7:  ${terminal.white}
 
 # Bright colors
-color8:  ${terminal_black}
-color9:  ${red_bright}
-color10: ${green_bright}
-color11: ${yellow_bright}
-color12: ${blue_bright}
-color13: ${magenta_bright}
-color14: ${cyan_bright}
-color15: ${fg}
+color8:  ${terminal.black_bright}
+color9:  ${terminal.red_bright}
+color10: ${terminal.green_bright}
+color11: ${terminal.yellow_bright}
+color12: ${terminal.blue_bright}
+color13: ${terminal.magenta_bright}
+color14: ${terminal.cyan_bright}
+color15: ${terminal.white_bright}
 
 # Extended colors
 color16: ${orange}
 color17: ${red1}
 ]],
-    extended_colors
+    colors
   )
 
   return termux


### PR DESCRIPTION
## Description

Refs: #648 

## Screenshots
![Screenshot_20241024-161802_Termux](https://github.com/user-attachments/assets/3df70ecb-1327-4c4c-ba27-2fed95cbff14)
![Screenshot_20241024-161840_Termux](https://github.com/user-attachments/assets/c7155ec4-8bab-4db7-b857-8e33755d2b34)
![Screenshot_20241024-161938_Termux](https://github.com/user-attachments/assets/931d35e2-c8f6-451d-bbc3-210519920227)
![Screenshot_20241024-162005_Termux](https://github.com/user-attachments/assets/3e1e0f02-29f4-431b-b01a-10cb5f6d56c1)


