### PR TITLE
fix(blink): blink highlight group additions

### DIFF
--- a/lua/tokyonight/groups/blink.lua
+++ b/lua/tokyonight/groups/blink.lua
@@ -6,17 +6,21 @@ M.url = "https://github.com/Saghen/blink.cmp"
 function M.get(c, opts)
   -- stylua: ignore
   local ret = {
-    BlinkCmpDoc             = { fg = c.fg, bg               = c.bg_float },
-    BlinkCmpDocBorder       = { fg = c.border_highlight, bg = c.bg_float },
-    BlinkCmpGhostText       = { fg = c.terminal_black },
-    BlinkCmpKindCodeium     = { fg = c.teal, bg             = c.none },
-    BlinkCmpKindCopilot     = { fg = c.teal, bg             = c.none },
-    BlinkCmpKindDefault     = { fg = c.fg_dark, bg          = c.none },
-    BlinkCmpKindSupermaven  = { fg = c.teal, bg             = c.none },
-    BlinkCmpKindTabNine     = { fg = c.teal, bg             = c.none },
-    BlinkCmpLabel           = { fg = c.fg, bg               = c.none },
-    BlinkCmpLabelDeprecated = { fg = c.fg_gutter, bg        = c.none, strikethrough = true },
-    BlinkCmpLabelMatch      = { fg = c.blue1, bg            = c.none },
+    BlinkCmpDoc                 = { fg = c.fg, bg               = c.bg_float },
+    BlinkCmpDocBorder           = { fg = c.border_highlight, bg = c.bg_float },
+    BlinkCmpGhostText           = { fg = c.terminal_black },
+    BlinkCmpKindCodeium         = { fg = c.teal, bg             = c.none },
+    BlinkCmpKindCopilot         = { fg = c.teal, bg             = c.none },
+    BlinkCmpKindDefault         = { fg = c.fg_dark, bg          = c.none },
+    BlinkCmpKindSupermaven      = { fg = c.teal, bg             = c.none },
+    BlinkCmpKindTabNine         = { fg = c.teal, bg             = c.none },
+    BlinkCmpLabel               = { fg = c.fg, bg               = c.none },
+    BlinkCmpLabelDeprecated     = { fg = c.fg_gutter, bg        = c.none, strikethrough = true },
+    BlinkCmpLabelMatch          = { fg = c.blue1, bg            = c.none },
+    BlinkCmpMenu                = { fg = c.fg, bg               = c.bg_float },
+    BlinkCmpMenuBorder          = { fg = c.border_highlight, bg = c.bg_float },
+    BlinkCmpSignatureHelp       = { fg = c.fg, bg               = c.bg_float },
+    BlinkCmpSignatureHelpBorder = { fg = c.border_highlight, bg = c.bg_float },
   }
 
   require("tokyonight.groups.kinds").kinds(ret, "BlinkCmpKind%s")


### PR DESCRIPTION


## Description

Blink.cmp currently has a broken tokyonight color scheme due to some highlight groups not being set.
This fixes the issues with cmp menu bg and border as well as signature border

## Screenshots
BEFORE
![Screenshot from 2024-12-18 18-27-56](https://github.com/user-attachments/assets/ac50b84a-b724-4230-8873-4205394c2dd3)

AFTER
![Screenshot from 2024-12-18 18-26-26](https://github.com/user-attachments/assets/73f78955-bc98-45bd-b5c9-ebcde74d23a1)
![Screenshot from 2024-12-18 18-27-14](https://github.com/user-attachments/assets/c12e04dc-4ad5-4af1-be90-c362d1d70e6b)

> Screenshots have transparent theme, but I can take some of default theme if needed
