### PR TITLE
fix(yazi): update yazi theme to use the new theme syntax in yazi 0.4

### DIFF
--- a/extras/yazi/tokyonight_day.toml
+++ b/extras/yazi/tokyonight_day.toml
@@ -31,15 +31,21 @@ count_selected = { fg = "#3760bf", bg = "#7890dd" }
 border_symbol = "│"
 border_style  = { fg = "#4094a3" }
 
+# Mode
+[mode]
+normal_main = { fg = "#d0d5e3", bg = "#2e7de9", bold = true }
+normal_alt  = { fg = "#2e7de9", bg = "#d0d5e3", bold = true }
+
+select_main = { fg = "#d0d5e3", bg = "#9854f1", bold = true }
+select_alt  = { fg = "#9854f1", bg = "#d0d5e3", bold = true }
+
+unset_main  = { fg = "#d0d5e3", bg = "#7847bd", bold = true }
+unset_alt   = { fg = "#7847bd", bg = "#d0d5e3", bold = true }
+
 [status]
 separator_open  = ""
 separator_close = ""
 separator_style = { fg = "#a8aecb", bg = "#a8aecb" }
-
-# Mode
-mode_normal = { fg = "#d0d5e3", bg = "#2e7de9", bold = true }
-mode_select = { fg = "#d0d5e3", bg = "#9854f1", bold = true }
-mode_unset  = { fg = "#d0d5e3", bg = "#7847bd", bold = true }
 
 # Progress
 progress_label  = { fg = "#6172b0", bold = true }
@@ -47,11 +53,11 @@ progress_normal = { fg = "#e1e2e7" }
 progress_error  = { fg = "#f52a65" }
 
 # Permissions
-permissions_t = { fg = "#2e7de9" }
-permissions_r = { fg = "#8c6c3e" }
-permissions_w = { fg = "#f52a65" }
-permissions_x = { fg = "#587539" }
-permissions_s = { fg = "#a1a6c5" }
+perm_type  = { fg = "#2e7de9" }
+perm_read  = { fg = "#8c6c3e" }
+perm_write = { fg = "#f52a65" }
+perm_exec  = { fg = "#587539" }
+perm_sep   = { fg = "#a1a6c5" }
 
 [select]
 border   = { fg = "#4094a3" }

--- a/extras/yazi/tokyonight_moon.toml
+++ b/extras/yazi/tokyonight_moon.toml
@@ -31,15 +31,21 @@ count_selected = { fg = "#c8d3f5", bg = "#3e68d7" }
 border_symbol = "│"
 border_style  = { fg = "#589ed7" }
 
+# Mode
+[mode]
+normal_main = { fg = "#1e2030", bg = "#82aaff", bold = true }
+normal_alt  = { fg = "#82aaff", bg = "#1e2030", bold = true }
+
+select_main = { fg = "#1e2030", bg = "#c099ff", bold = true }
+select_alt  = { fg = "#c099ff", bg = "#1e2030", bold = true }
+
+unset_main  = { fg = "#1e2030", bg = "#fca7ea", bold = true }
+unset_alt   = { fg = "#fca7ea", bg = "#1e2030", bold = true }
+
 [status]
 separator_open  = ""
 separator_close = ""
 separator_style = { fg = "#3b4261", bg = "#3b4261" }
-
-# Mode
-mode_normal = { fg = "#1e2030", bg = "#82aaff", bold = true }
-mode_select = { fg = "#1e2030", bg = "#c099ff", bold = true }
-mode_unset  = { fg = "#1e2030", bg = "#fca7ea", bold = true }
 
 # Progress
 progress_label  = { fg = "#828bb8", bold = true }
@@ -47,11 +53,11 @@ progress_normal = { fg = "#222436" }
 progress_error  = { fg = "#ff757f" }
 
 # Permissions
-permissions_t = { fg = "#82aaff" }
-permissions_r = { fg = "#ffc777" }
-permissions_w = { fg = "#ff757f" }
-permissions_x = { fg = "#c3e88d" }
-permissions_s = { fg = "#444a73" }
+perm_type  = { fg = "#82aaff" }
+perm_read  = { fg = "#ffc777" }
+perm_write = { fg = "#ff757f" }
+perm_exec  = { fg = "#c3e88d" }
+perm_sep   = { fg = "#444a73" }
 
 [select]
 border   = { fg = "#589ed7" }

--- a/extras/yazi/tokyonight_night.toml
+++ b/extras/yazi/tokyonight_night.toml
@@ -31,15 +31,21 @@ count_selected = { fg = "#c0caf5", bg = "#3d59a1" }
 border_symbol = "│"
 border_style  = { fg = "#27a1b9" }
 
+# Mode
+[mode]
+normal_main = { fg = "#16161e", bg = "#7aa2f7", bold = true }
+normal_alt  = { fg = "#7aa2f7", bg = "#16161e", bold = true }
+
+select_main = { fg = "#16161e", bg = "#bb9af7", bold = true }
+select_alt  = { fg = "#bb9af7", bg = "#16161e", bold = true }
+
+unset_main  = { fg = "#16161e", bg = "#9d7cd8", bold = true }
+unset_alt   = { fg = "#9d7cd8", bg = "#16161e", bold = true }
+
 [status]
 separator_open  = ""
 separator_close = ""
 separator_style = { fg = "#3b4261", bg = "#3b4261" }
-
-# Mode
-mode_normal = { fg = "#16161e", bg = "#7aa2f7", bold = true }
-mode_select = { fg = "#16161e", bg = "#bb9af7", bold = true }
-mode_unset  = { fg = "#16161e", bg = "#9d7cd8", bold = true }
 
 # Progress
 progress_label  = { fg = "#a9b1d6", bold = true }
@@ -47,11 +53,11 @@ progress_normal = { fg = "#1a1b26" }
 progress_error  = { fg = "#f7768e" }
 
 # Permissions
-permissions_t = { fg = "#7aa2f7" }
-permissions_r = { fg = "#e0af68" }
-permissions_w = { fg = "#f7768e" }
-permissions_x = { fg = "#9ece6a" }
-permissions_s = { fg = "#414868" }
+perm_type  = { fg = "#7aa2f7" }
+perm_read  = { fg = "#e0af68" }
+perm_write = { fg = "#f7768e" }
+perm_exec  = { fg = "#9ece6a" }
+perm_sep   = { fg = "#414868" }
 
 [select]
 border   = { fg = "#27a1b9" }

--- a/extras/yazi/tokyonight_storm.toml
+++ b/extras/yazi/tokyonight_storm.toml
@@ -31,15 +31,21 @@ count_selected = { fg = "#c0caf5", bg = "#3d59a1" }
 border_symbol = "│"
 border_style  = { fg = "#29a4bd" }
 
+# Mode
+[mode]
+normal_main = { fg = "#1f2335", bg = "#7aa2f7", bold = true }
+normal_alt  = { fg = "#7aa2f7", bg = "#1f2335", bold = true }
+
+select_main = { fg = "#1f2335", bg = "#bb9af7", bold = true }
+select_alt  = { fg = "#bb9af7", bg = "#1f2335", bold = true }
+
+unset_main  = { fg = "#1f2335", bg = "#9d7cd8", bold = true }
+unset_alt   = { fg = "#9d7cd8", bg = "#1f2335", bold = true }
+
 [status]
 separator_open  = ""
 separator_close = ""
 separator_style = { fg = "#3b4261", bg = "#3b4261" }
-
-# Mode
-mode_normal = { fg = "#1f2335", bg = "#7aa2f7", bold = true }
-mode_select = { fg = "#1f2335", bg = "#bb9af7", bold = true }
-mode_unset  = { fg = "#1f2335", bg = "#9d7cd8", bold = true }
 
 # Progress
 progress_label  = { fg = "#a9b1d6", bold = true }
@@ -47,11 +53,11 @@ progress_normal = { fg = "#24283b" }
 progress_error  = { fg = "#f7768e" }
 
 # Permissions
-permissions_t = { fg = "#7aa2f7" }
-permissions_r = { fg = "#e0af68" }
-permissions_w = { fg = "#f7768e" }
-permissions_x = { fg = "#9ece6a" }
-permissions_s = { fg = "#414868" }
+perm_type  = { fg = "#7aa2f7" }
+perm_read  = { fg = "#e0af68" }
+perm_write = { fg = "#f7768e" }
+perm_exec  = { fg = "#9ece6a" }
+perm_sep   = { fg = "#414868" }
 
 [select]
 border   = { fg = "#29a4bd" }


### PR DESCRIPTION
## Description

Fixes the status bar colors not getting applied in yazi 0.4 due to the changes introduced [here](https://github.com/sxyazi/yazi/pull/1953).

## Screenshots
tokyonight-moon before:

![2025-01-04 19-24-51](https://github.com/user-attachments/assets/94a5538e-cb25-4b7a-8767-01f21236caee)
![2025-01-04 19-25-01](https://github.com/user-attachments/assets/59b1a600-6f47-4ce8-837a-cf7bfe7dca1e)

tokyonight-moon after:

![2025-01-04 19-25-43](https://github.com/user-attachments/assets/d0d2b230-1e39-4a9b-a26d-9fddb225fd65)
![2025-01-04 19-25-50](https://github.com/user-attachments/assets/defff676-2420-418b-bc30-8671a7481983)

