### PR TITLE
fix(treesitter): import module color

### DIFF
--- a/lua/tokyonight/groups/treesitter.lua
+++ b/lua/tokyonight/groups/treesitter.lua
@@ -67,7 +67,7 @@ function M.get(c, opts)
     ["@markup.strikethrough"]       = { strikethrough = true },
     ["@markup.strong"]              = { bold = true },
     ["@markup.underline"]           = { underline = true },
-    ["@module"]                     = "Include",
+    ["@module"]                     = "Directory",
     ["@module.builtin"]             = { fg = c.red }, -- Variable names that are defined by the languages, like `this` or `self`.
     ["@namespace.builtin"]          = "@variable.builtin",
     ["@none"]                       = {},


### PR DESCRIPTION
## Description

Before the change it shows import and module name the same color that requires a bit more time to find where ends import statement and starts module name.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

Before:
<img width="612" alt="Screenshot 2025-01-18 at 02 58 13" src="https://github.com/user-attachments/assets/d5ebdd64-4060-455f-9fb3-63dc256a4241" />

After:
<img width="595" alt="Screenshot 2025-01-18 at 02 57 06" src="https://github.com/user-attachments/assets/51e711b9-e7f6-4ecd-bbbc-3781cb716dd4" />
