### PR TITLE
feat(extra): update yazi theme for yazi new release

### DIFF
--- a/lua/tokyonight/extra/yazi.lua
+++ b/lua/tokyonight/extra/yazi.lua
@@ -52,9 +52,9 @@ unset_main  = { fg = "${black}", bg = "${purple}", bold = true }
 unset_alt   = { fg = "${purple}", bg = "${fg_gutter}" }
 
 [status]
-separator_open    = ""
-separator_close   = ""
-# separator_style = { fg = "${fg_gutter}", bg = "${fg_gutter}" }
+overall   = { fg = "${fg}", bg = "${bg_dark}" }
+sep_left  = { open = "", close = "" }
+sep_right = { open = "", close = "" }
 
 # Progress
 progress_label  = { fg = "${fg_dark}", bold = true }

--- a/lua/tokyonight/extra/yazi.lua
+++ b/lua/tokyonight/extra/yazi.lua
@@ -57,9 +57,9 @@ sep_left  = { open = "", close = "" }
 sep_right = { open = "", close = "" }
 
 # Progress
-progress_label  = { fg = "${fg_dark}", bold = true }
-progress_normal = { fg = "${bg}" }
-progress_error  = { fg = "${red}" }
+progress_label  = { fg = "${fg}", bold = true }
+progress_normal = { fg = "${blue0}", bg = "${bg_highlight}" }
+progress_error  = { fg = "${red1}", bg = "${bg_highlight}" }
 
 # Permissions
 perm_type  = { fg = "${blue}" }
@@ -94,7 +94,7 @@ icon_command = ""
 [tasks]
 border  = { fg = "${border_highlight}" }
 title   = { fg = "${border_highlight}" }
-hovered = { fg = "${fg}", bg="${bg_visual}" }
+hovered = { fg = "${fg}", bg = "${bg_visual}" }
 
 # Which
 [which]

--- a/lua/tokyonight/extra/yazi.lua
+++ b/lua/tokyonight/extra/yazi.lua
@@ -22,7 +22,7 @@ find_keyword  = { fg = "${bg_dark}", bg = "${orange}", bold = true }
 find_position = { fg = "${blue2}", bg = "${bg_search}", bold = true }
 
 # Marker
-marker_copied   = { fg = "${green1}", bg = "${green1}" }
+marker_copied   = { fg = "${green}", bg = "${green}" }
 marker_cut      = { fg = "${red}", bg = "${red}" }
 marker_marked   = { fg = "${magenta}", bg = "${magenta}" }
 marker_selected = { fg = "${blue}", bg = "${blue}" }
@@ -33,9 +33,9 @@ tab_inactive = { fg = "${fg_gutter}", bg = "${bg}" }
 tab_width    = 1
 
 # Count
-count_copied   = { fg = "${fg}", bg = "${green2}" }
-count_cut      = { fg = "${fg}", bg = "${red1}" }
-count_selected = { fg = "${fg}", bg = "${blue0}" }
+count_copied   = { fg = "${bg_dark}", bg = "${green}" }
+count_cut      = { fg = "${bg_dark}", bg = "${red}" }
+count_selected = { fg = "${bg_dark}", bg = "${blue}" }
 
 # Border
 border_symbol = "│"

--- a/lua/tokyonight/extra/yazi.lua
+++ b/lua/tokyonight/extra/yazi.lua
@@ -162,8 +162,11 @@ rules = [
 	{ name = "*", is = "exec"  , fg = "${green}" },
 
 	# Fallback
-	{ name = "*/", fg = "${blue}" }
+	{ name = "*/", fg = "${blue}" },
+	{ name = "*", fg = "${fg_sidebar}" }
 ]
+
+# TODO: add filetype colors based on mini.icon
     ]],
     colors
   )


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
This PR is a theme update of yazi.
Updated/Edited:
 - yazi statusline (see https://github.com/sxyazi/yazi/pull/2321 and https://github.com/sxyazi/yazi/pull/2313)
 - progress bar (For normal situation, follows noice lsp progress bar color. For error, changes the blue0->red1)
 - File color fallback
## Related Issue(s)
No issue related
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots
1. Yazi statusline updated(in Yazi 25.2.11 (Arch Linux 2025-02-16) sep_left/sep_right have no effect):
![Screenshot 2025-02-20 23-54-46](https://github.com/user-attachments/assets/769a052e-f165-4207-82f7-87aa9e2ced1b)
(below is when sep_left/sep_right effects the statusline):
![Screenshot 2025-02-20 23-55-32](https://github.com/user-attachments/assets/fc098d3c-941b-4140-be0e-f4b4883c3758)

2. Progress Bar(Normal):
![Screenshot 2025-02-20 23-58-52](https://github.com/user-attachments/assets/ebe5ed03-21db-4348-aa70-68764c0c9526)

<!-- Add screenshots of the changes if applicable. -->

