### PR TITLE
feat: Add active buffer styling for helix

### DIFF
--- a/extras/helix/tokyonight_moon.toml
+++ b/extras/helix/tokyonight_moon.toml
@@ -63,6 +63,7 @@ type = { fg = "#65bcff" }
 "type.enum" = { fg = "#65bcff" }
 "type.enum.variant" = { fg = "#ff966c" }
 "ui.background" = { bg = "bg" }
+"ui.bufferline.active" = { fg = "#c0caf5", bg = "#283457" }
 "ui.cursor" = { bg = "#c8d3f5", fg = "#222436" }
 "ui.cursor.match" = { fg = "#ff966c", modifiers = ["bold"] }
 "ui.linenr" = { fg = "#3b4261" }

--- a/extras/helix/tokyonight_night.toml
+++ b/extras/helix/tokyonight_night.toml
@@ -63,6 +63,7 @@ type = { fg = "#2ac3de" }
 "type.enum" = { fg = "#2ac3de" }
 "type.enum.variant" = { fg = "#ff9e64" }
 "ui.background" = { bg = "bg" }
+"ui.bufferline.active" = { fg = "#c0caf5", bg = "#283457" }
 "ui.cursor" = { bg = "#c0caf5", fg = "#1a1b26" }
 "ui.cursor.match" = { fg = "#ff9e64", modifiers = ["bold"] }
 "ui.linenr" = { fg = "#3b4261" }

--- a/extras/helix/tokyonight_storm.toml
+++ b/extras/helix/tokyonight_storm.toml
@@ -63,6 +63,7 @@ type = { fg = "#2ac3de" }
 "type.enum" = { fg = "#2ac3de" }
 "type.enum.variant" = { fg = "#ff9e64" }
 "ui.background" = { bg = "bg" }
+"ui.bufferline.active" = { fg = "#c0caf5", bg = "#565f89" }
 "ui.cursor" = { bg = "#c0caf5", fg = "#24283b" }
 "ui.cursor.match" = { fg = "#ff9e64", modifiers = ["bold"] }
 "ui.linenr" = { fg = "#3b4261" }


### PR DESCRIPTION
# Description
The helix themes currently lack styling for helix bufferline active tabs, which makes it more difficult to see which current buffer tab is active at a glance.

This PR suggests colors for the tab using the current theme's color pallet.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

# Screenshots
## tokyonight night
With
<img width="445" alt="image" src="https://github.com/user-attachments/assets/543b745b-f2f7-499c-939a-afc4af831117" />
Without
<img width="438" alt="image" src="https://github.com/user-attachments/assets/bc1fcc7a-d44f-44f4-935f-4848f97996d4" />
## tokyonight storm
With
<img width="439" alt="image" src="https://github.com/user-attachments/assets/ecc20743-b0e8-4db9-870c-307e017cfe48" />
Without
<img width="435" alt="image" src="https://github.com/user-attachments/assets/db70e86b-7bfb-4394-b016-eec9ba47b185" />

## tokyonight moon
With
<img width="440" alt="image" src="https://github.com/user-attachments/assets/214b9889-0c7e-4646-94cb-63ec6e626653" />
Without
<img width="436" alt="image" src="https://github.com/user-attachments/assets/ff6b8a6d-999a-4416-bfeb-a09584b4bc41" />


<!-- Add screenshots of the changes if applicable. -->

