### PR TITLE
feat(extra): add Vivaldi Browser themes

### DIFF
--- a/extras/vivaldi/README.md
+++ b/extras/vivaldi/README.md
@@ -1,0 +1,42 @@
+# Tokyo Night for Vivaldi Browser
+
+The Tokyo Night theme collection for Vivaldi browser. Includes day, moon, night, and storm variants, each with 8 highlight color options (blue, yellow, green, teal, purple, magenta, orange, and red). Defaults to blue.
+
+## Usage
+
+Vivaldi themes must be provided as zip files with a specific structure. Each theme requires a JSON file named `settings.json` inside the zip archive.
+
+### Build script
+
+A script is included to build the theme files:
+
+1. Navigate to the `extras/vivaldi` directory
+2. Run the build script:
+
+   ```bash
+   ./build
+   ```
+
+   This creates zip files for each theme variant with the JSON file renamed to `settings.json`.
+
+### Manual Zipping
+
+If you prefer to manually create the theme files:
+
+1. Create a temporary directory
+2. Copy a theme JSON file (e.g., `tokyonight_day.json`) to this directory
+3. Rename it to `settings.json`
+4. Zip the file: 
+
+   ```bash
+   zip tokyonight_day.zip settings.json`
+   ```
+
+5. Repeat for each theme variant
+
+## Installation
+
+1. In Vivaldi, go to Settings > Themes
+2. Click "Import Themes" and select one of the zip files
+3. The theme will appear in your themes list
+4. Click the theme to apply it

--- a/extras/vivaldi/build
+++ b/extras/vivaldi/build
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CURRENT_DIR=$(pwd)
+TEMP_DIR=$(mktemp -d) || exit 1
+
+cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+
+trap cleanup EXIT
+
+for json_file in *.json; do
+  base_name=$(basename "$json_file" .json)
+  cp "$json_file" "$TEMP_DIR/settings.json"
+  (cd "$TEMP_DIR" && zip -q "$CURRENT_DIR/${base_name}.zip" settings.json)
+done

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -40,6 +40,7 @@ M.extras = {
   yazi             = { ext = "toml", url = "https://github.com/sxyazi/yazi", label = "Yazi" },
   vim              = { ext = "vim", url = "https://vimhelp.org/", label = "Vim", subdir = "colors", sep = "-" },
   vimium           = { ext = "css", url = "https://vimium.github.io/", label = "Vimium" },
+  vivaldi          = { ext = "json", url = "https://vivaldi.com", label = "Vivaldi" },
   zathura          = { ext = "zathurarc", url = "https://pwmt.org/projects/zathura/", label = "Zathura" },
   zellij           = { ext = "kdl", url = "https://zellij.dev/", label = "Zellij" },
 }

--- a/lua/tokyonight/extra/vivaldi.lua
+++ b/lua/tokyonight/extra/vivaldi.lua
@@ -1,0 +1,82 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @return string UUID
+local function generate_uuid()
+  local seed = tonumber(tostring(os.clock()):reverse():sub(1, 9))
+  math.randomseed(seed)
+  return string.gsub("xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx", "[xy]", function(c)
+    local v = (c == "x") and math.random(0, 0xf) or math.random(8, 0xb)
+    return string.format("%x", v)
+  end)
+end
+---
+--- @param colors ColorScheme
+--- @param color_hex string
+--- @param color_name string|nil
+--- @return string JSON
+local function generate_theme(colors, color_hex, color_name)
+  local colors = vim.deepcopy(colors)
+  colors._id = generate_uuid()
+
+  if color_name then
+    colors._style_name = colors._style_name .. " (" .. color_name .. ")"
+  end
+
+  return util.template([[
+{
+   "accentFromPage": false,
+   "accentOnWindow": true,
+   "accentSaturationLimit": 1,
+   "alpha": 1,
+   "backgroundImage": "",
+   "backgroundPosition": "stretch",
+   "blur": 0,
+   "colorAccentBg": "${bg_highlight}",
+   "colorBg": "${bg}",
+   "colorFg": "${fg}",
+   "colorHighlightBg": "]] .. color_hex .. [[",
+   "colorWindowBg": "${black}",
+   "contrast": 0,
+   "dimBlurred": false,
+   "engineVersion": 1,
+   "id": "${_id}",
+   "name": "${_style_name}",
+   "preferSystemAccent": false,
+   "radius": 14,
+   "simpleScrollbar": true,
+   "transparencyTabBar": false,
+   "transparencyTabs": false,
+   "url": "https://github.com/folke/tokyonight.nvim",
+   "version": 1
+}]], colors)
+end
+
+--- @param colors ColorScheme
+--- @return string
+function M.generate(colors)
+  local rainbow = {
+    "Blue",
+    "Yellow",
+    "Green",
+    "Teal",
+    "Purple",
+    "Magenta",
+    "Orange",
+    "Red",
+  }
+
+  for i = 1, #colors.rainbow do
+    local color_name = rainbow[i]
+    local color_hex = colors.rainbow[i]
+    local variant_fname = "vivaldi/" .. colors._name .. "_" .. color_name:lower() .. ".json"
+    print("[write] " .. variant_fname)
+    util.write("extras/" .. variant_fname, generate_theme(colors, color_hex, color_name))
+  end
+
+  -- return the first rainbow color (blue) as the default
+  return generate_theme(colors, colors.rainbow[1])
+end
+
+return M


### PR DESCRIPTION
## Description

Adds the themes for the Vivaldi browser. Included all the rainbow colors as variants for the highlight color. Also included a build script, since Vivaldi themes must be in a zip file with the theme JSON named "settings.json" within it.

## Related Issue(s)

N/A

## Screenshots

**Day**:
![image](https://github.com/user-attachments/assets/7f337895-1317-4d3e-9d51-d926ae703acf)

**Moon**:
![image](https://github.com/user-attachments/assets/d42f644e-cf9e-42c0-9285-b793edc1d894)

**Night**:
![image](https://github.com/user-attachments/assets/32f7d6d7-663a-47b9-b94b-3ac78d66ef87)

**Storm**:
![image](https://github.com/user-attachments/assets/33f30b7a-740b-42cc-9c87-68d500a979db)

### Variants

All using the Moon theme.

**Green**:
![image](https://github.com/user-attachments/assets/1f6bea08-1c31-4ecf-8179-7f099ddf689f)

**Magenta**:
![image](https://github.com/user-attachments/assets/36e68690-559f-457b-a896-eee055ac230a)

**Orange**:
![image](https://github.com/user-attachments/assets/cb2f1420-2d70-4c24-b509-a1c38435f8fc)

**Purple**:
![image](https://github.com/user-attachments/assets/9a298f78-5a90-4449-8a2a-f06742c2bc25)

**Red**:
![image](https://github.com/user-attachments/assets/a19d3dbc-ff8e-44f2-81f6-a499a3c4cc0c)

**Teal**:
![image](https://github.com/user-attachments/assets/952cb8ef-7289-4ffe-8fbb-3b59bb537bd6)

**Yellow**:
![image](https://github.com/user-attachments/assets/aebc8cda-1069-4c7a-8bb3-185bc8341607)