### PR TITLE
Cleanup alacritty theme

### DIFF
--- a/lua/tokyonight/extra/alacritty.lua
+++ b/lua/tokyonight/extra/alacritty.lua
@@ -17,10 +17,6 @@ function M.generate(colors)
 background = '${bg}'
 foreground = '${fg}'
 
-#[colors.cursor]
-#cursor = '${fg}'
-#text = '${bg}'
-
 # Normal colors
 [colors.normal]
 black = '${terminal.black}'
@@ -42,16 +38,6 @@ blue = '${terminal.blue_bright}'
 magenta = '${terminal.magenta_bright}'
 cyan = '${terminal.cyan_bright}'
 white = '${terminal.white_bright}'
-
-# Indexed Colors
-[[colors.indexed_colors]]
-index = 16
-color = '${orange}'
-
-[[colors.indexed_colors]]
-index = 17
-color = '${red1}'
-
 ]=],
     colors
   )


### PR DESCRIPTION
This PR cleans up a couple of issues with the Alacritty color scheme:

1. Removed redundant, commented-out cursor color. This duplicates the default Alacritty behavior of using the fg and bg reversed.

2. Fixes indexed colors 16 and 17. I show that xterm 256‑color standards ([source](https://www.ditig.com/256-colors-cheat-sheet)) indicate 16 and 17 should be Grey0 and NavyBlue, not orange and red. I'd be curious to know if there was some reason for mapping these two specific colors to orange and red. But it seems like that information may be lost to time. I went back in git history and I couldn't find any notes. I noticed this issue because this was causing the ngrok tool to render illegibly, since it apparently uses 16 as it's background color.
