### PR TITLE
Add theme for iSH, an x86 emulator for iOS and iPadOS.

### DIFF
--- a/lua/tokyonight/extra/iSH.lua
+++ b/lua/tokyonight/extra/iSH.lua
@@ -1,0 +1,43 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @param colors ColorScheme
+function M.generate(colors)
+  local ish = util.template(
+    [[
+{
+  "name": "${_style_name}",
+  "version": 1,
+  "shared": {
+    "backgroundColor": "${bg}",
+    "colorPaletteOverrides": [
+      "${terminal.black}",
+      "${terminal.red}",
+      "${terminal.green}",
+      "${terminal.yellow}",
+      "${terminal.blue}",
+      "${terminal.magenta}",
+      "${terminal.cyan}",
+      "${terminal.white}",
+      "${terminal.black_bright}",
+      "${terminal.red_bright}",
+      "${terminal.green_bright}",
+      "${terminal.yellow_bright}",
+      "${terminal.blue_bright}",
+      "${terminal.magenta_bright}",
+      "${terminal.cyan_bright}",
+      "${terminal.white_bright}",
+    ],
+    "cursorColor": "${fg}",
+    "foregroundColor": "${fg}"
+  }
+}
+
+]],
+    colors
+  )
+  return ish
+end
+
+return M

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -21,6 +21,7 @@ M.extras = {
   gnome_terminal   = { ext = "dconf", url = "https://gitlab.gnome.org/GNOME/gnome-terminal", label = "GNOME Terminal" },
   helix            = { ext = "toml", url = "https://helix-editor.com/", label = "Helix" },
   iterm            = { ext = "itermcolors", url = "https://iterm2.com/", label = "iTerm" },
+  ish              = { ext = "json", url = "https://ish.app", label = "iSH "},
   kitty            = { ext = "conf", url = "https://sw.kovidgoyal.net/kitty/conf.html", label = "Kitty" },
   lazygit          = { ext = "yml", url = "https://github.com/jesseduffield/lazygit", label = "Lazygit" },
   lua              = { ext = "lua", url = "https://www.lua.org", label = "Lua Table for testing" },


### PR DESCRIPTION
## Description
Added Lua file for iSH theme and added entry in `extras/init.lua` for iSH theme.

