### PR TITLE
feat(extra): base16 and base24 schemes

### DIFF
--- a/extras/base16/tokyonight_day.yaml
+++ b/extras/base16/tokyonight_day.yaml
@@ -1,0 +1,21 @@
+system: "base16"
+name: "Tokyo Night Day"
+author: "folke"
+variant: "light"
+palette:
+  base00: "#e1e2e7" # ----
+  base01: "#c4c8da" # ---
+  base02: "#a8aecb" # --
+  base03: "#848cb5" # -
+  base04: "#6172b0" # +
+  base05: "#3760bf" # ++
+  base06: "#006a83" # +++
+  base07: "#2e5857" # ++++
+  base08: "#f52a65" # red
+  base09: "#b15c00" # orange
+  base0A: "#8c6c3e" # yellow
+  base0B: "#587539" # green
+  base0C: "#007197" # cyan
+  base0D: "#2e7de9" # blue
+  base0E: "#7847bd" # purple
+  base0F: "#9854f1" # magenta

--- a/extras/base16/tokyonight_moon.yaml
+++ b/extras/base16/tokyonight_moon.yaml
@@ -1,0 +1,21 @@
+system: "base16"
+name: "Tokyo Night Moon"
+author: "folke"
+variant: "dark"
+palette:
+  base00: "#222436" # ----
+  base01: "#2f334d" # ---
+  base02: "#3b4261" # --
+  base03: "#636da6" # -
+  base04: "#828bb8" # +
+  base05: "#c8d3f5" # ++
+  base06: "#89ddff" # +++
+  base07: "#b4f9f8" # ++++
+  base08: "#ff757f" # red
+  base09: "#ff966c" # orange
+  base0A: "#ffc777" # yellow
+  base0B: "#c3e88d" # green
+  base0C: "#86e1fc" # cyan
+  base0D: "#82aaff" # blue
+  base0E: "#fca7ea" # purple
+  base0F: "#c099ff" # magenta

--- a/extras/base16/tokyonight_night.yaml
+++ b/extras/base16/tokyonight_night.yaml
@@ -1,0 +1,21 @@
+system: "base16"
+name: "Tokyo Night"
+author: "folke"
+variant: "dark"
+palette:
+  base00: "#1a1b26" # ----
+  base01: "#292e42" # ---
+  base02: "#3b4261" # --
+  base03: "#565f89" # -
+  base04: "#a9b1d6" # +
+  base05: "#c0caf5" # ++
+  base06: "#89ddff" # +++
+  base07: "#b4f9f8" # ++++
+  base08: "#f7768e" # red
+  base09: "#ff9e64" # orange
+  base0A: "#e0af68" # yellow
+  base0B: "#9ece6a" # green
+  base0C: "#7dcfff" # cyan
+  base0D: "#7aa2f7" # blue
+  base0E: "#9d7cd8" # purple
+  base0F: "#bb9af7" # magenta

--- a/extras/base16/tokyonight_storm.yaml
+++ b/extras/base16/tokyonight_storm.yaml
@@ -1,0 +1,21 @@
+system: "base16"
+name: "Tokyo Night Storm"
+author: "folke"
+variant: "dark"
+palette:
+  base00: "#24283b" # ----
+  base01: "#292e42" # ---
+  base02: "#3b4261" # --
+  base03: "#565f89" # -
+  base04: "#a9b1d6" # +
+  base05: "#c0caf5" # ++
+  base06: "#89ddff" # +++
+  base07: "#b4f9f8" # ++++
+  base08: "#f7768e" # red
+  base09: "#ff9e64" # orange
+  base0A: "#e0af68" # yellow
+  base0B: "#9ece6a" # green
+  base0C: "#7dcfff" # cyan
+  base0D: "#7aa2f7" # blue
+  base0E: "#9d7cd8" # purple
+  base0F: "#bb9af7" # magenta

--- a/extras/base24/tokyonight_day.yaml
+++ b/extras/base24/tokyonight_day.yaml
@@ -1,0 +1,29 @@
+system: "base16"
+name: "Tokyo Night Day"
+author: "folke"
+variant: "light"
+palette:
+  base00: "#e1e2e7" # ----
+  base01: "#c4c8da" # ---
+  base02: "#a8aecb" # --
+  base03: "#848cb5" # -
+  base04: "#6172b0" # +
+  base05: "#3760bf" # ++
+  base06: "#006a83" # +++
+  base07: "#2e5857" # ++++
+  base08: "#f52a65" # red
+  base09: "#b15c00" # orange
+  base0A: "#8c6c3e" # yellow
+  base0B: "#587539" # green
+  base0C: "#007197" # cyan
+  base0D: "#2e7de9" # blue
+  base0E: "#7847bd" # purple
+  base0F: "#9854f1" # magenta
+  base10: "#d0d5e3" # darker background
+  base11: "#c1c9df" # darkest background
+  base12: "#ff4774" # bright red
+  base13: "#a27629" # bright yellow
+  base14: "#5c8524" # bright green
+  base15: "#007ea8" # bright cyan
+  base16: "#358aff" # bright blue
+  base17: "#a463ff" # bright purple

--- a/extras/base24/tokyonight_moon.yaml
+++ b/extras/base24/tokyonight_moon.yaml
@@ -1,0 +1,29 @@
+system: "base16"
+name: "Tokyo Night Moon"
+author: "folke"
+variant: "dark"
+palette:
+  base00: "#222436" # ----
+  base01: "#2f334d" # ---
+  base02: "#3b4261" # --
+  base03: "#636da6" # -
+  base04: "#828bb8" # +
+  base05: "#c8d3f5" # ++
+  base06: "#89ddff" # +++
+  base07: "#b4f9f8" # ++++
+  base08: "#ff757f" # red
+  base09: "#ff966c" # orange
+  base0A: "#ffc777" # yellow
+  base0B: "#c3e88d" # green
+  base0C: "#86e1fc" # cyan
+  base0D: "#82aaff" # blue
+  base0E: "#fca7ea" # purple
+  base0F: "#c099ff" # magenta
+  base10: "#1e2030" # darker background
+  base11: "#191B29" # darkest background
+  base12: "#ff8d94" # bright red
+  base13: "#ffd8ab" # bright yellow
+  base14: "#c7fb6d" # bright green
+  base15: "#b2ebff" # bright cyan
+  base16: "#9ab8ff" # bright blue
+  base17: "#caabff" # bright purple

--- a/extras/base24/tokyonight_night.yaml
+++ b/extras/base24/tokyonight_night.yaml
@@ -1,0 +1,29 @@
+system: "base16"
+name: "Tokyo Night"
+author: "folke"
+variant: "dark"
+palette:
+  base00: "#1a1b26" # ----
+  base01: "#292e42" # ---
+  base02: "#3b4261" # --
+  base03: "#565f89" # -
+  base04: "#a9b1d6" # +
+  base05: "#c0caf5" # ++
+  base06: "#89ddff" # +++
+  base07: "#b4f9f8" # ++++
+  base08: "#f7768e" # red
+  base09: "#ff9e64" # orange
+  base0A: "#e0af68" # yellow
+  base0B: "#9ece6a" # green
+  base0C: "#7dcfff" # cyan
+  base0D: "#7aa2f7" # blue
+  base0E: "#9d7cd8" # purple
+  base0F: "#bb9af7" # magenta
+  base10: "#16161e" # darker background
+  base11: "#0C0E14" # darkest background
+  base12: "#ff899d" # bright red
+  base13: "#faba4a" # bright yellow
+  base14: "#9fe044" # bright green
+  base15: "#a4daff" # bright cyan
+  base16: "#8db0ff" # bright blue
+  base17: "#c7a9ff" # bright purple

--- a/extras/base24/tokyonight_storm.yaml
+++ b/extras/base24/tokyonight_storm.yaml
@@ -1,0 +1,29 @@
+system: "base16"
+name: "Tokyo Night Storm"
+author: "folke"
+variant: "dark"
+palette:
+  base00: "#24283b" # ----
+  base01: "#292e42" # ---
+  base02: "#3b4261" # --
+  base03: "#565f89" # -
+  base04: "#a9b1d6" # +
+  base05: "#c0caf5" # ++
+  base06: "#89ddff" # +++
+  base07: "#b4f9f8" # ++++
+  base08: "#f7768e" # red
+  base09: "#ff9e64" # orange
+  base0A: "#e0af68" # yellow
+  base0B: "#9ece6a" # green
+  base0C: "#7dcfff" # cyan
+  base0D: "#7aa2f7" # blue
+  base0E: "#9d7cd8" # purple
+  base0F: "#bb9af7" # magenta
+  base10: "#1f2335" # darker background
+  base11: "#1b1e2d" # darkest background
+  base12: "#ff899d" # bright red
+  base13: "#faba4a" # bright yellow
+  base14: "#9fe044" # bright green
+  base15: "#a4daff" # bright cyan
+  base16: "#8db0ff" # bright blue
+  base17: "#c7a9ff" # bright purple

--- a/lua/tokyonight/extra/base16.lua
+++ b/lua/tokyonight/extra/base16.lua
@@ -1,0 +1,55 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @param colors ColorScheme
+function M.generate(colors, _, opts)
+  colors.base16 = {
+    variant = opts.style == "day" and "light" or "dark",
+    base00 = colors.bg,
+    base01 = colors.bg_highlight,
+    base02 = colors.fg_gutter,
+    base03 = colors.comment,
+    base04 = colors.fg_dark,
+    base05 = colors.fg,
+    base06 = colors.blue5,
+    base07 = colors.blue6,
+    base08 = colors.red,
+    base09 = colors.orange,
+    base0A = colors.yellow,
+    base0B = colors.green,
+    base0C = colors.cyan,
+    base0D = colors.blue,
+    base0E = colors.purple,
+    base0F = colors.magenta,
+  }
+  local base16 = util.template(
+    [[
+system: "base16"
+name: "${_style_name}"
+author: "folke"
+variant: "${base16.variant}"
+palette:
+  base00: "${base16.base00}" # ----
+  base01: "${base16.base01}" # ---
+  base02: "${base16.base02}" # --
+  base03: "${base16.base03}" # -
+  base04: "${base16.base04}" # +
+  base05: "${base16.base05}" # ++
+  base06: "${base16.base06}" # +++
+  base07: "${base16.base07}" # ++++
+  base08: "${base16.base08}" # red
+  base09: "${base16.base09}" # orange
+  base0A: "${base16.base0A}" # yellow
+  base0B: "${base16.base0B}" # green
+  base0C: "${base16.base0C}" # cyan
+  base0D: "${base16.base0D}" # blue
+  base0E: "${base16.base0E}" # purple
+  base0F: "${base16.base0F}" # magenta
+]],
+    colors
+  )
+  return base16
+end
+
+return M

--- a/lua/tokyonight/extra/base24.lua
+++ b/lua/tokyonight/extra/base24.lua
@@ -1,0 +1,71 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @param colors ColorScheme
+function M.generate(colors, _, opts)
+  colors.base24 = {
+    variant = opts.style == "day" and "light" or "dark",
+    base00 = colors.bg,
+    base01 = colors.bg_highlight,
+    base02 = colors.fg_gutter,
+    base03 = colors.comment,
+    base04 = colors.fg_dark,
+    base05 = colors.fg,
+    base06 = colors.blue5,
+    base07 = colors.blue6,
+    base08 = colors.red,
+    base09 = colors.orange,
+    base0A = colors.yellow,
+    base0B = colors.green,
+    base0C = colors.cyan,
+    base0D = colors.blue,
+    base0E = colors.purple,
+    base0F = colors.magenta,
+    base10 = colors.bg_dark,
+    base11 = colors.bg_dark1,
+    base12 = colors.terminal.red_bright,
+    base13 = colors.terminal.yellow_bright,
+    base14 = colors.terminal.green_bright,
+    base15 = colors.terminal.cyan_bright,
+    base16 = colors.terminal.blue_bright,
+    base17 = colors.terminal.magenta_bright,
+  }
+  local base16 = util.template(
+    [[
+system: "base16"
+name: "${_style_name}"
+author: "folke"
+variant: "${base24.variant}"
+palette:
+  base00: "${base24.base00}" # ----
+  base01: "${base24.base01}" # ---
+  base02: "${base24.base02}" # --
+  base03: "${base24.base03}" # -
+  base04: "${base24.base04}" # +
+  base05: "${base24.base05}" # ++
+  base06: "${base24.base06}" # +++
+  base07: "${base24.base07}" # ++++
+  base08: "${base24.base08}" # red
+  base09: "${base24.base09}" # orange
+  base0A: "${base24.base0A}" # yellow
+  base0B: "${base24.base0B}" # green
+  base0C: "${base24.base0C}" # cyan
+  base0D: "${base24.base0D}" # blue
+  base0E: "${base24.base0E}" # purple
+  base0F: "${base24.base0F}" # magenta
+  base10: "${base24.base10}" # darker background
+  base11: "${base24.base11}" # darkest background
+  base12: "${base24.base12}" # bright red
+  base13: "${base24.base13}" # bright yellow
+  base14: "${base24.base14}" # bright green
+  base15: "${base24.base15}" # bright cyan
+  base16: "${base24.base16}" # bright blue
+  base17: "${base24.base17}" # bright purple
+]],
+    colors
+  )
+  return base16
+end
+
+return M

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -8,6 +8,8 @@ local M = {}
 M.extras = {
   aerc             = { ext = "ini", url = "https://git.sr.ht/~rjarry/aerc/", label = "Aerc" },
   alacritty        = { ext = "toml", url = "https://github.com/alacritty/alacritty", label = "Alacritty" },
+  base16           = { ext = "yaml", url = "https://github.com/tinted-theming/home", label = "Base16" },
+  base24           = { ext = "yaml", url = "https://github.com/tinted-theming/home", label = "Base24" },
   delta            = { ext = "gitconfig", url = "https://github.com/dandavison/delta", label = "Delta" },
   discord          = { ext = "css", url ="https://betterdiscord.app/", label = "(Better-)Discord"},
   dunst            = { ext = "dunstrc", url = "https://dunst-project.org/", label = "Dunst" },


### PR DESCRIPTION
## Description

I want to use base16 to configure various applications on my system but found the "tokyonight" schemes in https://github.com/tinted-theming/schemes lacking. I made this for myself, but I figured other people might find these useful.

## Related Issue(s)

https://github.com/folke/tokyonight.nvim/issues/101

## Screenshots

Various apps on my system configured to use the `tokyonight_moon` base16 theme:
![Screenshot_2025-04-23_21-41-32](https://github.com/user-attachments/assets/41a24851-d140-4612-8e53-3238c02d31cc)

