### PR TITLE
feat(extra): Add themes for Konsole

### DIFF
--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -22,6 +22,7 @@ M.extras = {
   helix            = { ext = "toml", url = "https://helix-editor.com/", label = "Helix" },
   iterm            = { ext = "itermcolors", url = "https://iterm2.com/", label = "iTerm" },
   kitty            = { ext = "conf", url = "https://sw.kovidgoyal.net/kitty/conf.html", label = "Kitty" },
+  konsole          = { ext = "colorscheme", url = "https://konsole.kde.org/", label = "Konsole" },
   lazygit          = { ext = "yml", url = "https://github.com/jesseduffield/lazygit", label = "Lazygit" },
   lua              = { ext = "lua", url = "https://www.lua.org", label = "Lua Table for testing" },
   prism            = { ext = "js", url = "https://prismjs.com", label = "Prism" },

--- a/lua/tokyonight/extra/konsole.lua
+++ b/lua/tokyonight/extra/konsole.lua
@@ -1,0 +1,95 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+---@param colors ColorScheme
+function M.generate(colors)
+  local konsole_colors = {}
+
+  for k, v in pairs(colors) do
+    local is_color = type(v) == "string" and v:find("^#[%x]") ~= nil
+    if is_color then
+      ---@type string
+      local hex = v:gsub("^#", "")
+      local r = tonumber(hex:sub(1, 2), 16)
+      local g = tonumber(hex:sub(3, 4), 16)
+      local b = tonumber(hex:sub(5, 6), 16)
+      konsole_colors[k] = string.format("%d,%d,%d", r, g, b)
+    else
+      konsole_colors[k] = v
+    end
+  end
+
+  local konsole = util.template(
+    [[
+[Background]
+Color=${bg}
+
+[BackgroundIntense]
+Color=${bg_visual}
+
+[Foreground]
+Color=${fg}
+
+[ForegroundIntense]
+Bold=true
+Color=${fg}
+
+[Color0]
+Color=${terminal.black}
+
+[Color0Intense]
+Color=${terminal.black_bright}
+
+[Color1]
+Color=${terminal.red}
+
+[Color1Intense]
+Color=${terminal.red_bright}
+
+[Color2]
+Color=${terminal.green}
+
+[Color2Intense]
+Color=${terminal.green_bright}
+
+[Color3]
+Color=${terminal.yellow}
+
+[Color3Intense]
+Color=${terminal.yellow_bright}
+
+[Color4]
+Color=${terminal.blue}
+
+[Color4Intense]
+Color=${terminal.blue_bright}
+
+[Color5]
+Color=${terminal.magenta}
+
+[Color5Intense]
+Color=${terminal.magenta_bright}
+
+[Color6]
+Color=${terminal.cyan}
+
+[Color6Intense]
+Color=${terminal.cyan_bright}
+
+[Color7]
+Color=${terminal.white}
+
+[Color7Intense]
+Color=${terminal.white_bright}
+
+[General]
+Description=${_style_name}
+Opacity=1
+]],
+    konsole_colors
+  )
+  return konsole
+end
+
+return M


### PR DESCRIPTION
## Description

I've added the template to generate themes for the Konsole terminal emulator

## Related Issue(s)

- Addresses this closed PR: https://github.com/folke/tokyonight.nvim/pull/128

## Screenshots

Used the following script (a variation of [this page](https://askubuntu.com/questions/27314/script-to-display-all-terminal-colors):

```bash
clear

for x in {0..1}; do
    for i in {30..37}; do
        for a in {40..47}; do
            echo -ne "\e[$x;$i;$a""m\\\e[$x;$i;$a""m\e[0;37;40m "
        done

        echo
    done
done

read -r -p "" NONE

unset NONE
```

### Day

<img width="1380" height="495" alt="TN_Day_Konsole" src="https://github.com/user-attachments/assets/23a55501-466f-4dd1-920c-fa9c5c938efd" />

### Moon

<img width="1364" height="504" alt="TN_Moon_Konsole" src="https://github.com/user-attachments/assets/6b666d96-a6f6-4dc4-872a-206c78100c8a" />

### Storm

<img width="1360" height="496" alt="TN_Storm_Konsole" src="https://github.com/user-attachments/assets/6dc9b926-8c34-4cec-9b5b-e330a700e467" />

### Night

<img width="1347" height="493" alt="TN_Night_Konsole" src="https://github.com/user-attachments/assets/55871718-6ccb-4800-a53a-a2a73d5b0e05" />

