### PR TITLE
fix(extras): edit name to match iSH.lua file for genertate colorschemes

### DIFF
--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -24,7 +24,7 @@ M.extras = {
   gnome_terminal   = { ext = "dconf", url = "https://gitlab.gnome.org/GNOME/gnome-terminal", label = "GNOME Terminal" },
   helix            = { ext = "toml", url = "https://helix-editor.com/", label = "Helix" },
   iterm            = { ext = "itermcolors", url = "https://iterm2.com/", label = "iTerm" },
-  ish              = { ext = "json", url = "https://ish.app", label = "iSH "},
+  iSH              = { ext = "json", url = "https://ish.app", label = "iSH "},
   kitty            = { ext = "conf", url = "https://sw.kovidgoyal.net/kitty/conf.html", label = "Kitty" },
   konsole          = { ext = "colorscheme", url = "https://konsole.kde.org/", label = "Konsole" },
   lazygit          = { ext = "yml", url = "https://github.com/jesseduffield/lazygit", label = "Lazygit" },


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

We can't generate colorscheme since ish in init.lua table cannot match iSH.lua.
So I edit the value from ish to iSH in order to generate extras colorschemes.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

Below is the result of running ./script/build before editing table in lua/tokyonight/extra/init.lua ish -> iSH

<img width="2308" height="1156" alt="图片" src="https://github.com/user-attachments/assets/4b69929a-d68c-4fe7-816c-8a8c3d5d690c" />
