### PR TITLE
feat(extra): add Gemini CLI theme

### DIFF
--- a/extras/gemini_cli/README.md
+++ b/extras/gemini_cli/README.md
@@ -1,0 +1,43 @@
+# Tokyo Night for Gemini CLI
+
+This directory contains the Tokyo Night color scheme for the [Gemini CLI](https://github.com/google-gemini/gemini-cli).
+
+## Installation
+
+1. Choose your preferred Tokyo Night style (Storm, Moon, Night, or Day).
+2. Open your Gemini CLI `settings.json` file. You can find this in:
+   - **Linux/macOS:** `~/.gemini/settings.json`
+   - **Windows:** `%USERPROFILE%\.gemini\settings.json`
+3. Add or update the `ui.theme` property with the absolute path to your chosen theme file:
+
+```json
+{
+  "ui": {
+    "theme": "/absolute/path/to/tokyonight_night.json"
+  }
+}
+```
+
+Alternatively, you can copy the contents of the JSON file into the `ui.customThemes` object in your `settings.json`:
+
+```json
+{
+  "ui": {
+    "customThemes": {
+      "Tokyo Night": {
+        "name": "Tokyo Night",
+        "type": "custom",
+        ...
+      }
+    },
+    "theme": "Tokyo Night"
+  }
+}
+```
+
+## Styles
+
+- **tokyonight_storm.json**: Tokyo Night Storm (Dark)
+- **tokyonight_moon.json**: Tokyo Night Moon (Dark)
+- **tokyonight_night.json**: Tokyo Night (Dark)
+- **tokyonight_day.json**: Tokyo Night Day (Light)

--- a/lua/tokyonight/extra/gemini_cli.lua
+++ b/lua/tokyonight/extra/gemini_cli.lua
@@ -1,0 +1,52 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @param colors ColorScheme
+--- @return string
+function M.generate(colors)
+  return util.template([[
+{
+  "name": "${_style_name}",
+  "type": "custom",
+  "text": {
+    "primary": "${fg}",
+    "secondary": "${fg_dark}",
+    "response": "${fg}"
+  },
+  "background": {
+    "primary": "${bg}",
+    "diff": {
+      "added": "${diff.add}",
+      "removed": "${diff.delete}"
+    }
+  },
+  "border": {
+    "default": "${bg_highlight}",
+    "focused": "${blue}"
+  },
+  "ui": {
+    "comment": "${comment}",
+    "symbol": "${fg_dark}",
+    "gradient": ["${blue}", "${magenta}", "${cyan}"]
+  },
+  "Background": "${bg}",
+  "Foreground": "${fg}",
+  "LightBlue": "${blue1}",
+  "AccentBlue": "${magenta}",
+  "AccentPurple": "${purple}",
+  "AccentCyan": "${cyan}",
+  "AccentGreen": "${orange}",
+  "AccentYellow": "${green}",
+  "AccentRed": "${red}",
+  "DiffAdded": "${diff.add}",
+  "DiffRemoved": "${diff.delete}",
+  "Comment": "${comment}",
+  "Gray": "${fg_dark}",
+  "DarkGray": "${bg_dark}",
+  "GradientColors": ["${blue}", "${magenta}", "${cyan}"]
+}
+]], colors)
+end
+
+return M

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -19,6 +19,7 @@ M.extras = {
   foot             = { ext = "ini", url = "https://codeberg.org/dnkl/foot", label = "Foot" },
   fuzzel           = { ext = "ini", url = "https://codeberg.org/dnkl/fuzzel", label = "Fuzzel" },
   fzf              = { ext = "sh", url = "https://github.com/junegunn/fzf", label = "Fzf" },
+  gemini_cli       = { ext = "json", url = "https://github.com/google-gemini/gemini-cli", label = "Gemini CLI" },
   ghostty          = { ext = "", url = "https://github.com/ghostty-org/ghostty", label = "Ghostty" },
   gitui            = { ext = "ron", url = "https://github.com/extrawurst/gitui", label = "GitUI" },
   gnome_terminal   = { ext = "dconf", url = "https://gitlab.gnome.org/GNOME/gnome-terminal", label = "GNOME Terminal" },


### PR DESCRIPTION
## Description

This PR adds support for generating Gemini CLI (https://github.com/google-gemini/gemini-cli) themes. It provides an extra template that maps the Tokyo Night palette to the custom theme format used by the CLI, supporting all four styles (Storm, Moon, Night, and Day).

The implementation includes:
- Comprehensive Mapping: Maps Tokyo Night colors to Gemini CLI's syntax highlighting and modern semantic UI tokens.
- Diff Support: Utilizes the pre-blended colors.diff background shades for improved readability in terminal diff views.
- Documentation: Includes a README in extras/gemini_cli/ with instructions for sideloading the generated JSON files.

## Screenshots

<img width="2664" height="1946" alt="2025-12-20_22-26" src="https://github.com/user-attachments/assets/75fc48a0-cb34-4ac9-9269-7a38188b5c9d" />
