### PR TITLE
fix(main): prevent Neovim 0.12 TUI background autocmd removal on first colorscheme load

### DIFF
--- a/lua/tokyonight/init.lua
+++ b/lua/tokyonight/init.lua
@@ -11,7 +11,7 @@ function M.load(opts)
   local style_bg = opts.style == "day" and "light" or "dark"
 
   if bg ~= style_bg then
-    if vim.g.colors_name == "tokyonight-" .. opts.style then
+    if vim.g.colors_name == nil or vim.g.colors_name == "tokyonight-" .. opts.style then
       opts.style = bg == "light" and (M.styles.light or "day") or (M.styles.dark or "moon")
     else
       vim.o.background = style_bg


### PR DESCRIPTION
## Description


https://github.com/neovim/neovim/commit/d460928263d0ff53283f301dfcb85f5b6e17d2ac#diff-49225a49c226c2f1b36f966d0178c556e204cdc0b660c80db9e4568e03f6ef99R689 

In Neovim 0.12, when the terminal reports a light background, the initial colorscheme still explicitly set background=dark during setup. However, setting the background option at this stage triggers Neovim to remove its internal TermResponse AutoCommand, which is responsible for handling the CSI 2031 terminal response and automatic background switching.

As a result, Neovim loses the ability to automatically switch between dark and light backgrounds based on terminal feedback. This PR avoids setting the background option on the first colorscheme load, preserving Neovim's TermResponse AutoCommand and ensuring correct background detection and switching.
## Related Issue(s)


## Checklist

- [ ✔] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
