### PR TITLE
fix(extras.pi): brighten diff colors to increase readability

### DIFF
--- a/lua/tokyonight/extra/pi.lua
+++ b/lua/tokyonight/extra/pi.lua
@@ -5,6 +5,9 @@ local M = {}
 --- @param colors ColorScheme
 function M.generate(colors)
   colors.tool_error_bg = util.blend_bg(colors.error, 0.05)
+  colors.tool_diff_added = util.blend_bg(colors.green2, 0.8)
+  colors.tool_diff_removed = util.blend_bg(colors.red1, 0.65)
+  colors.tool_diff_context = util.blend_fg(colors.blue7, 0.3)
   local pi = util.template(
     [[{
   "$schema": "https://raw.githubusercontent.com/badlogic/pi-mono/main/packages/coding-agent/src/modes/interactive/theme/theme-schema.json",
@@ -45,9 +48,9 @@ function M.generate(colors)
     "mdHr": "${orange}",
     "mdListBullet": "${orange}",
 
-    "toolDiffAdded": "${diff.add}",
-    "toolDiffRemoved": "${diff.delete}",
-    "toolDiffContext": "${diff.text}",
+    "toolDiffAdded": "${tool_diff_added}",
+    "toolDiffRemoved": "${tool_diff_removed}",
+    "toolDiffContext": "${tool_diff_context}",
 
     "syntaxComment": "${comment}",
     "syntaxKeyword": "${purple}",


### PR DESCRIPTION
## Description

I found the out of the box colors for the tool diffs too dark and very unreadable. I took a stab at brightening them a bit, but the numbers I chose were largely arbitrary and just me eyeballing.

## Related Issue(s)

Didn't open an issue, but willing to if desired.

## Screenshots

Before:
<img width="1918" height="1552" alt="image" src="https://github.com/user-attachments/assets/e1fc6dbe-1d2a-454f-8ae6-bb22bf4242ec" />

After:
<img width="1915" height="1541" alt="image" src="https://github.com/user-attachments/assets/05ccc1b6-35ec-4c14-839b-986b30f3110b" />

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
