### PR TITLE
fix(extra.pi): change code block font from bg to fg

### DIFF
--- a/lua/tokyonight/extra/pi.lua
+++ b/lua/tokyonight/extra/pi.lua
@@ -38,7 +38,7 @@ function M.generate(colors)
     "mdLink": "${teal}",
     "mdLinkUrl": "${comment}",
     "mdCode": "${blue}",
-    "mdCodeBlock": "${bg_dark}",
+    "mdCodeBlock": "${fg_dark}",
     "mdCodeBlockBorder": "${comment}",
     "mdQuote": "${comment}",
     "mdQuoteBorder": "${comment}",


### PR DESCRIPTION
## Description

Swap from `bg_dark` to `fg_dark` for the default code block font color. If there's a code block in a clanker's reply with no language specified it defaults the text color to this color and it was unreadable.

(Note: sorry for the potential PR spam -- I went with a separate PR from #765 since they are slightly unrelated.)

## Related Issue(s)

No issue, willing to open one.

## Screenshots

Before:
<img width="1086" height="208" alt="image" src="https://github.com/user-attachments/assets/0a801443-2acd-48fe-b8e8-8e5b988696f2" />

After:
<img width="1060" height="231" alt="image" src="https://github.com/user-attachments/assets/bc4bbf4f-3b52-48c8-8ee6-1ffc9265bc25" />

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
