### PR TITLE
feat(extra): add Atuin theme

### DIFF
--- a/extras/atuin/README.md
+++ b/extras/atuin/README.md
@@ -1,0 +1,22 @@
+# Tokyo Night for Atuin
+
+This directory contains the Tokyo Night color scheme for [Atuin](https://atuin.sh/).
+
+## Installation
+
+1. Choose your preferred Tokyo Night style (Storm, Moon, Night, or Day).
+2. Copy the TOML file to your Atuin themes directory: `~/.config/atuin/themes/`.
+3. Update your configuration in `~/.config/atuin/config.toml`:
+
+```toml
+[theme]
+name = "tokyonight_storm"
+```
+For more details on custom theme configuration, see the [official documentation](https://docs.atuin.sh/cli/guide/theming/).
+
+## Styles
+
+- **tokyonight_storm.json**: Tokyo Night Storm (Dark)
+- **tokyonight_moon.json**: Tokyo Night Moon (Dark)
+- **tokyonight_night.json**: Tokyo Night (Dark)
+- **tokyonight_day.json**: Tokyo Night Day (Light)

--- a/extras/atuin/README.md
+++ b/extras/atuin/README.md
@@ -16,7 +16,7 @@ For more details on custom theme configuration, see the [official documentation]
 
 ## Styles
 
-- **tokyonight_storm.json**: Tokyo Night Storm (Dark)
-- **tokyonight_moon.json**: Tokyo Night Moon (Dark)
-- **tokyonight_night.json**: Tokyo Night (Dark)
-- **tokyonight_day.json**: Tokyo Night Day (Light)
+- **tokyonight_storm.toml**: Tokyo Night Storm (Dark)
+- **tokyonight_moon.toml**: Tokyo Night Moon (Dark)
+- **tokyonight_night.toml**: Tokyo Night (Dark)
+- **tokyonight_day.toml**: Tokyo Night Day (Light)

--- a/lua/tokyonight/extra/atuin.lua
+++ b/lua/tokyonight/extra/atuin.lua
@@ -1,0 +1,29 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @param colors ColorScheme
+--- @return string
+function M.generate(colors)
+  return util.template([[
+# Theme: ${_style_name}
+# Upstream: https://github.com/folke/tokyonight.nvim/tree/main/extras/atuin
+
+[theme]
+name = "${_name}"
+parent = "default"
+
+[colors]
+AlertInfo = "${green1}"
+AlertWarn = "${yellow}"
+AlertError = "${red}"
+Annotation = "${terminal_black}"
+Base = "${fg}"
+Guidance = "${orange}"
+Important = "${blue}"
+Title = "${magenta}"
+Muted = "${dark3}"
+]], colors)
+end
+
+return M

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -9,6 +9,7 @@ M.extras = {
   aerc             = { ext = "ini", url = "https://git.sr.ht/~rjarry/aerc/", label = "Aerc" },
   aider            = { ext = "yml", url = "https://aider.chat", label = "Aider" },
   alacritty        = { ext = "toml", url = "https://github.com/alacritty/alacritty", label = "Alacritty" },
+  atuin            = { ext = "toml", url = "https://github.com/atuinsh/atuin", label = "Atuin" },
   btop             = { ext = "theme", url = "https://github.com/aristocratos/btop", label = "Btop++" },
   delta            = { ext = "gitconfig", url = "https://github.com/dandavison/delta", label = "Delta" },
   discord          = { ext = "css", url ="https://betterdiscord.app/", label = "(Better-)Discord"},


### PR DESCRIPTION
## Description

Add TokyoNight theme support for [Atuin](https://atuin.sh/) in the following style variants:

- **tokyonight_storm.toml**: Tokyo Night Storm (Dark)
- **tokyonight_moon.toml**: Tokyo Night Moon (Dark)
- **tokyonight_night.toml**: Tokyo Night (Dark)
- **tokyonight_day.jsonv**: Tokyo Night Day (Light)

Please feel free to modify or suggest modifications on the chosen colors. I am more than happy to review the selections.

## Screenshots

### Day

<img width="951" height="508" alt="day" src="https://github.com/user-attachments/assets/15a62b21-f62b-455e-ad8e-6717631044aa" />

### Moon

<img width="951" height="508" alt="moon" src="https://github.com/user-attachments/assets/3d0b8f0a-882a-45c0-91e6-9256494a8917" />

### Storm

<img width="951" height="508" alt="storm" src="https://github.com/user-attachments/assets/948d629c-9b8e-48dc-9176-cbd1fd44bf10" />

### Night

<img width="951" height="508" alt="night" src="https://github.com/user-attachments/assets/e68e0645-9b03-4b97-8987-7eba31a56e04" />


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
