### PR TITLE
fix(extras.bufferline): fix selected buffer indicator background

### DIFF
--- a/lua/tokyonight/groups/bufferline.lua
+++ b/lua/tokyonight/groups/bufferline.lua
@@ -6,7 +6,7 @@ M.url = "https://github.com/akinsho/bufferline.nvim"
 function M.get(c, opts)
   -- stylua: ignore
   return {
-    BufferLineIndicatorSelected = { fg = c.git.change },
+    BufferLineIndicatorSelected = { fg = c.git.change, bg = c.bg },
   }
 end
 


### PR DESCRIPTION
## Description

Fix selected buffer indicator's transparent background.

## Related Issue(s)

No issues.

## Screenshots

Before:
<img width="460" height="266" alt="Screenshot 2026-04-18 at 20 09 55" src="https://github.com/user-attachments/assets/32ae65c5-71d4-4fb4-9703-a9e419145336" />

After:
<img width="460" height="266" alt="Screenshot 2026-04-18 at 20 10 33" src="https://github.com/user-attachments/assets/5fe5d902-e73c-4881-9f59-7be3f931c74b" />

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
