### PR TITLE
feat(extras.sqlit): add themes for sqlit

### DIFF
--- a/extras/sqlit/tokyonight_day.json
+++ b/extras/sqlit/tokyonight_day.json
@@ -1,0 +1,23 @@
+{
+  "_note": "Tokyo Night Day",
+  "theme": {
+    "name": "tokyonight_day",
+    "dark": true,
+    "primary": "#3760bf",
+    "secondary": "#6172b0",
+    "accent": "#2e7de9",
+    "warning": "#8c6c3e",
+    "error": "#c64343",
+    "success": "#587539",
+    "foreground": "#3760bf",
+    "background": "#e1e2e7",
+    "surface": "#d0d5e3",
+    "panel": "#c4c8da",
+    "variables": {
+      "border": "#7890dd",
+      "input-selection-background": "#b7c1e3",
+      "mode-normal-color": "#8c6c3e",
+      "mode-insert-color": "#587539"
+    }
+  }
+}

--- a/extras/sqlit/tokyonight_moon.json
+++ b/extras/sqlit/tokyonight_moon.json
@@ -1,0 +1,23 @@
+{
+  "_note": "Tokyo Night Moon",
+  "theme": {
+    "name": "tokyonight_moon",
+    "dark": true,
+    "primary": "#c8d3f5",
+    "secondary": "#828bb8",
+    "accent": "#82aaff",
+    "warning": "#ffc777",
+    "error": "#c53b53",
+    "success": "#c3e88d",
+    "foreground": "#c8d3f5",
+    "background": "#222436",
+    "surface": "#1e2030",
+    "panel": "#2f334d",
+    "variables": {
+      "border": "#3e68d7",
+      "input-selection-background": "#2d3f76",
+      "mode-normal-color": "#ffc777",
+      "mode-insert-color": "#c3e88d"
+    }
+  }
+}

--- a/extras/sqlit/tokyonight_night.json
+++ b/extras/sqlit/tokyonight_night.json
@@ -1,0 +1,23 @@
+{
+  "_note": "Tokyo Night",
+  "theme": {
+    "name": "tokyonight_night",
+    "dark": true,
+    "primary": "#c0caf5",
+    "secondary": "#a9b1d6",
+    "accent": "#7aa2f7",
+    "warning": "#e0af68",
+    "error": "#db4b4b",
+    "success": "#9ece6a",
+    "foreground": "#c0caf5",
+    "background": "#1a1b26",
+    "surface": "#16161e",
+    "panel": "#292e42",
+    "variables": {
+      "border": "#3d59a1",
+      "input-selection-background": "#283457",
+      "mode-normal-color": "#e0af68",
+      "mode-insert-color": "#9ece6a"
+    }
+  }
+}

--- a/extras/sqlit/tokyonight_storm.json
+++ b/extras/sqlit/tokyonight_storm.json
@@ -1,0 +1,23 @@
+{
+  "_note": "Tokyo Night Storm",
+  "theme": {
+    "name": "tokyonight_storm",
+    "dark": true,
+    "primary": "#c0caf5",
+    "secondary": "#a9b1d6",
+    "accent": "#7aa2f7",
+    "warning": "#e0af68",
+    "error": "#db4b4b",
+    "success": "#9ece6a",
+    "foreground": "#c0caf5",
+    "background": "#24283b",
+    "surface": "#1f2335",
+    "panel": "#292e42",
+    "variables": {
+      "border": "#3d59a1",
+      "input-selection-background": "#2e3c64",
+      "mode-normal-color": "#e0af68",
+      "mode-insert-color": "#9ece6a"
+    }
+  }
+}

--- a/lua/tokyonight/extra/init.lua
+++ b/lua/tokyonight/extra/init.lua
@@ -38,6 +38,7 @@ M.extras = {
   slack            = { ext = "txt", url = "https://slack.com", label = "Slack" },
   sublime          = { ext = "tmTheme", url = "https://www.sublimetext.com/docs/themes", label = "Sublime Text" },
   spotify_player   = { ext = "toml", url = "https://github.com/aome510/spotify-player", label = "Spotify Player" },
+  sqlit            = { ext = "json", url = "https://github.com/Maxteabag/sqlit", label = "Sqlit" },
   tailwindv4       = { ext = "css", url = "https://tailwindcss.com", label = "Tailwind CSS (v4)" },
   terminator       = { ext = "conf", url = "https://gnome-terminator.readthedocs.io/en/latest/config.html", label = "Terminator" },
   termux           = { ext = "properties", url = "https://termux.dev/", label = "Termux" },

--- a/lua/tokyonight/extra/sqlit.lua
+++ b/lua/tokyonight/extra/sqlit.lua
@@ -1,0 +1,37 @@
+local util = require("tokyonight.util")
+
+local M = {}
+
+--- @param colors ColorScheme
+function M.generate(colors)
+  return util.template(M.template, colors)
+end
+
+M.template = [=[
+{
+  "_note": "${_style_name}",
+  "theme": {
+    "name": "${_name}",
+    "dark": true,
+    "primary": "${fg}",
+    "secondary": "${fg_dark}",
+    "accent": "${blue}",
+    "warning": "${warning}",
+    "error": "${error}",
+    "success": "${green}",
+    "foreground": "${fg}",
+    "background": "${bg}",
+    "surface": "${bg_dark}",
+    "panel": "${bg_highlight}",
+    "variables": {
+      "border": "${blue0}",
+      "input-selection-background": "${bg_visual}",
+      "mode-normal-color": "${yellow}",
+      "mode-insert-color": "${green}"
+    }
+  }
+}
+]=]
+
+return M
+


### PR DESCRIPTION
## Description

Add support for generating color theme for [sqlit](https://github.com/Maxteabag/sqlit).

## Related Issue(s)

N/A

## Screenshots

<img width="1379" height="974" alt="Screenshot 2026-05-13 at 7 01 37 AM" src="https://github.com/user-attachments/assets/fdeed88a-df5e-4cb9-8da3-93efaa02c78d" />
<img width="1383" height="968" alt="Screenshot 2026-05-13 at 7 01 39 AM" src="https://github.com/user-attachments/assets/eb126163-66f4-4de9-83a8-6a8ae20f9109" />
<img width="1389" height="982" alt="Screenshot 2026-05-13 at 7 01 30 AM" src="https://github.com/user-attachments/assets/ca45a051-f29c-41b3-93b8-93fbbdb1da8c" />
<img width="1374" height="986" alt="Screenshot 2026-05-13 at 7 01 32 AM" src="https://github.com/user-attachments/assets/74273fc8-2d8b-472a-9344-dfaffa59cffe" />

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
