### PR TITLE
fix(extra yazi): replace `name` with `url` in `filetype.rules`

### DIFF
--- a/lua/tokyonight/extra/yazi.lua
+++ b/lua/tokyonight/extra/yazi.lua
@@ -160,12 +160,12 @@ rules = [
 	# { mime = "inode/x-empty", fg = "${red}" },
 
 	# Special files
-	{ name = "*", is = "orphan", bg = "${red}" },
-	{ name = "*", is = "exec"  , fg = "${green}" },
+	{ url = "*", is = "orphan", bg = "${red}" },
+	{ url = "*", is = "exec"  , fg = "${green}" },
 
 	# Fallback
-	{ name = "*/", fg = "${blue}" },
-	{ name = "*", fg = "${fg}" }
+	{ url = "*/", fg = "${blue}" },
+	{ url = "*", fg = "${fg}" }
 ]
     ]],
     colors


### PR DESCRIPTION
## Description

`name` was deprecated and replaced with `url` in <https://github.com/sxyazi/yazi/pull/3034>, which breaks the current Yazi themes. This simple change is the fix. It has been over half a year since the change was introduced, so this should be fine to add now.


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
