### PR TITLE
feat(highlight): set @lsp.types.variable to @variable

### DIFF
--- a/lua/tokyonight/groups/semantic_tokens.lua
+++ b/lua/tokyonight/groups/semantic_tokens.lua
@@ -30,7 +30,7 @@ function M.get(c)
     ["@lsp.type.string"]                       = "@string",
     ["@lsp.type.typeAlias"]                    = "@type.definition",
     ["@lsp.type.unresolvedReference"]          = { undercurl = true, sp = c.error },
-    ["@lsp.type.variable"]                     = {}, -- use treesitter styles for regular variables
+    ["@lsp.type.variable"]                     = "@variable", -- use treesitter styles for regular variables
     ["@lsp.typemod.class.defaultLibrary"]      = "@type.builtin",
     ["@lsp.typemod.enum.defaultLibrary"]       = "@type.builtin",
     ["@lsp.typemod.enumMember.defaultLibrary"] = "@constant.builtin",


### PR DESCRIPTION
solved: https://github.com/folke/tokyonight.nvim/issues/778

When it is set to clear, the highlight in format will never be shown

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
